### PR TITLE
Android automatic refactor - ObsoleteLayoutParam

### DIFF
--- a/app/src/main/res/layout/fragment_contact.xml
+++ b/app/src/main/res/layout/fragment_contact.xml
@@ -1,76 +1,69 @@
-<?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout  xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+<?xml version='1.0' encoding='utf-8'?>
+  <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent">
 
-    <ScrollView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@+id/scrollView6"
-        android:layout_alignParentTop="true"
-        android:layout_above="@+id/btnCancel"
-        android:fillViewport="true">
+  <ScrollView android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:id="@+id/scrollView6"
+    android:layout_alignParentTop="true"
+    android:layout_above="@+id/btnCancel"
+    android:fillViewport="true">
 
-        <LinearLayout
-            android:id="@+id/linearLayoutContact"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical"
-            android:padding="16dp" >
+    <LinearLayout android:id="@+id/linearLayoutContact"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:orientation="vertical"
+      android:padding="16dp">
 
-            <TextView
-                android:id="@+id/textLink"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/description_contact"
-                android:textAppearance="?android:attr/textAppearanceMedium"
-                android:textSize="15sp" />
-
-            <TextView
-                android:id="@+id/result_text_contact"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
-                android:layout_marginTop="10dp"
-                android:gravity="center_horizontal"
-                android:text="TextView"
-                android:textSize="20sp" />
-
-        </LinearLayout>
-    </ScrollView>
-
-    <Button
-        android:id="@+id/btnProceed"
+      <TextView android:id="@+id/textLink"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:background="@drawable/button_fullwidth"
-        android:padding="5dp"
-        android:text="@string/choose_action"
-        android:textColor="@android:color/white"
-        android:layout_alignParentBottom="true"
-        android:layout_toRightOf="@+id/imageView"
-        android:layout_margin="1dp" />
+        android:text="@string/description_contact"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:textSize="15sp"/>
 
-    <ImageView
-        android:layout_centerInParent="true"
-        android:layout_height="fill_parent"
-        android:layout_width="wrap_content"
-        android:id="@+id/imageView"
-        android:paddingLeft="2dp"
-        android:visibility="invisible" />
-
-    <Button
-        android:id="@+id/btnCancel"
+      <TextView android:id="@+id/result_text_contact"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:background="@drawable/button_fullwidth"
-        android:padding="5dp"
-        android:text="@string/abort_action"
-        android:textColor="@android:color/white"
-        android:layout_alignParentBottom="true"
-        android:layout_toLeftOf="@+id/imageView"
-        android:layout_margin="1dp" />
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="10dp"
+        android:gravity="center_horizontal"
+        android:text="TextView"
+        android:textSize="20sp"/>
+    </LinearLayout>
+  </ScrollView>
 
+  <Button android:id="@+id/btnProceed"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/button_fullwidth"
+    android:padding="5dp"
+    android:text="@string/choose_action"
+    android:textColor="@android:color/white"
+    android:layout_alignParentBottom="true"
+    android:layout_toRightOf="@+id/imageView"
+    android:layout_margin="1dp">
+    <!--Removed ObsoleteLayoutParam: layout_weight-->
+  </Button>
+
+  <ImageView android:layout_centerInParent="true"
+    android:layout_height="fill_parent"
+    android:layout_width="wrap_content"
+    android:id="@+id/imageView"
+    android:paddingLeft="2dp"
+    android:visibility="invisible"/>
+
+  <Button android:id="@+id/btnCancel"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/button_fullwidth"
+    android:padding="5dp"
+    android:text="@string/abort_action"
+    android:textColor="@android:color/white"
+    android:layout_alignParentBottom="true"
+    android:layout_toLeftOf="@+id/imageView"
+    android:layout_margin="1dp">
+    <!--Removed ObsoleteLayoutParam: layout_weight-->
+  </Button>
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_email.xml
+++ b/app/src/main/res/layout/fragment_email.xml
@@ -1,80 +1,76 @@
-<RelativeLayout  xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+<?xml version='1.0' encoding='UTF-8'?>
+  <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent">
 
-    <ScrollView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@+id/scrollView7"
-        android:layout_above="@+id/btnProceed"
-        android:layout_alignParentTop="true"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:fillViewport="true"
-        android:layout_alignRight="@+id/btnProceed"
-        android:layout_alignEnd="@+id/btnProceed">
+  <ScrollView android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:id="@+id/scrollView7"
+    android:layout_above="@+id/btnProceed"
+    android:layout_alignParentTop="true"
+    android:layout_alignParentLeft="true"
+    android:layout_alignParentStart="true"
+    android:fillViewport="true"
+    android:layout_alignRight="@+id/btnProceed"
+    android:layout_alignEnd="@+id/btnProceed">
 
-        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-            xmlns:tools="http://schemas.android.com/tools"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical"
-            android:padding="16dp"
-            tools:context=".ResultEmailActivity" >
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:tools="http://schemas.android.com/tools"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:orientation="vertical"
+      android:padding="16dp"
+      tools:context=".ResultEmailActivity">
 
-            <TextView
-                android:id="@+id/textLink"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/description_email"
-                android:textAppearance="?android:attr/textAppearanceMedium"
-                android:textSize="15sp"
-                android:textIsSelectable="true" />
-
-            <TextView
-                android:id="@+id/result_field_email"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_horizontal"
-                android:text="Test"
-                android:textAlignment="center"
-                android:textSize="20sp"
-                android:textIsSelectable="true" />
-
-        </LinearLayout>
-    </ScrollView>
-
-    <Button
-        android:id="@+id/btnProceed"
+      <TextView android:id="@+id/textLink"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:background="@drawable/button_fullwidth"
-        android:padding="5dp"
-        android:text="@string/choose_action"
-        android:textColor="@android:color/white"
-        android:layout_alignParentBottom="true"
-        android:layout_toRightOf="@+id/imageView"
-        android:layout_margin="1dp" />
+        android:text="@string/description_email"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:textSize="15sp"
+        android:textIsSelectable="true"/>
 
-    <ImageView
-        android:layout_centerInParent="true"
-        android:layout_height="fill_parent"
+      <TextView android:id="@+id/result_field_email"
         android:layout_width="wrap_content"
-        android:id="@+id/imageView"
-        android:paddingLeft="2dp"
-        android:visibility="invisible" />
-
-    <Button
-        android:id="@+id/btnCancel"
-        android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:background="@drawable/button_fullwidth"
-        android:padding="5dp"
-        android:text="@string/abort_action"
-        android:textColor="@android:color/white"
-        android:layout_alignParentBottom="true"
-        android:layout_toLeftOf="@+id/imageView"
-        android:layout_margin="1dp" />
+        android:layout_gravity="center_horizontal"
+        android:text="Test"
+        android:textAlignment="center"
+        android:textSize="20sp"
+        android:textIsSelectable="true"/>
+    </LinearLayout>
+  </ScrollView>
+
+  <Button android:id="@+id/btnProceed"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/button_fullwidth"
+    android:padding="5dp"
+    android:text="@string/choose_action"
+    android:textColor="@android:color/white"
+    android:layout_alignParentBottom="true"
+    android:layout_toRightOf="@+id/imageView"
+    android:layout_margin="1dp">
+    <!--Removed ObsoleteLayoutParam: layout_weight-->
+  </Button>
+
+  <ImageView android:layout_centerInParent="true"
+    android:layout_height="fill_parent"
+    android:layout_width="wrap_content"
+    android:id="@+id/imageView"
+    android:paddingLeft="2dp"
+    android:visibility="invisible"/>
+
+  <Button android:id="@+id/btnCancel"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/button_fullwidth"
+    android:padding="5dp"
+    android:text="@string/abort_action"
+    android:textColor="@android:color/white"
+    android:layout_alignParentBottom="true"
+    android:layout_toLeftOf="@+id/imageView"
+    android:layout_margin="1dp">
+    <!--Removed ObsoleteLayoutParam: layout_weight-->
+  </Button>
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_product.xml
+++ b/app/src/main/res/layout/fragment_product.xml
@@ -1,79 +1,75 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<?xml version='1.0' encoding='UTF-8'?>
+  <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="fill_parent"
+  android:layout_height="fill_parent"
+  android:background="#FFFFFF"
+  android:orientation="vertical">
+
+  <ScrollView android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:id="@+id/scrollView8"
+    android:layout_alignParentTop="true"
+    android:layout_above="@+id/btnProceed"
+    android:fillViewport="true">
+
+    <LinearLayout android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+      android:orientation="vertical"
+      android:padding="16dp">
+
+      <TextView android:id="@+id/textLink"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/description_product"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:textSize="15sp"/>
+
+      <TextView android:id="@+id/result_field_product"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignWithParentIfMissing="true"
+        android:layout_marginTop="20dp"
+        android:gravity="center_vertical|center_horizontal"
+        android:text="Example application"
+        android:textSize="16sp"
+        android:textIsSelectable="true">
+        <!--Removed ObsoleteLayoutParam: layout_alignParentRight-->
+        <!--Removed ObsoleteLayoutParam: layout_alignParentTop-->
+        <!--Removed ObsoleteLayoutParam: layout_centerInParent-->
+      </TextView>
+    </LinearLayout>
+  </ScrollView>
+
+  <Button android:id="@+id/btnProceed"
     android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/button_fullwidth"
+    android:padding="5dp"
+    android:text="@string/choose_action"
+    android:textColor="@android:color/white"
+    android:layout_alignParentBottom="true"
+    android:layout_toRightOf="@+id/imageView"
+    android:layout_margin="1dp">
+    <!--Removed ObsoleteLayoutParam: layout_weight-->
+  </Button>
+
+  <ImageView android:layout_centerInParent="true"
     android:layout_height="fill_parent"
-    android:background="#FFFFFF"
-    android:orientation="vertical">
+    android:layout_width="wrap_content"
+    android:id="@+id/imageView"
+    android:paddingLeft="2dp"
+    android:visibility="invisible"/>
 
-    <ScrollView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@+id/scrollView8"
-        android:layout_alignParentTop="true"
-        android:layout_above="@+id/btnProceed"
-        android:fillViewport="true">
-
-        <LinearLayout
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:padding="16dp" >
-
-            <TextView
-                android:id="@+id/textLink"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/description_product"
-                android:textAppearance="?android:attr/textAppearanceMedium"
-                android:textSize="15sp" />
-
-            <TextView
-                android:id="@+id/result_field_product"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:layout_alignParentRight="true"
-                android:layout_alignParentTop="true"
-                android:layout_alignWithParentIfMissing="true"
-                android:layout_centerInParent="false"
-                android:layout_marginTop="20dp"
-                android:gravity="center_vertical|center_horizontal"
-                android:text="Example application"
-                android:textSize="16sp"
-                android:textIsSelectable="true" />
-
-        </LinearLayout>
-    </ScrollView>
-
-    <Button
-        android:id="@+id/btnProceed"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:background="@drawable/button_fullwidth"
-        android:padding="5dp"
-        android:text="@string/choose_action"
-        android:textColor="@android:color/white"
-        android:layout_alignParentBottom="true"
-        android:layout_toRightOf="@+id/imageView"
-        android:layout_margin="1dp" />
-
-    <ImageView
-        android:layout_centerInParent="true"
-        android:layout_height="fill_parent"
-        android:layout_width="wrap_content"
-        android:id="@+id/imageView"
-        android:paddingLeft="2dp"
-        android:visibility="invisible" />
-
-    <Button
-        android:id="@+id/btnCancel"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:background="@drawable/button_fullwidth"
-        android:padding="5dp"
-        android:text="@string/abort_action"
-        android:textColor="@android:color/white"
-        android:layout_alignParentBottom="true"
-        android:layout_toLeftOf="@+id/imageView"
-        android:layout_margin="1dp" />
+  <Button android:id="@+id/btnCancel"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/button_fullwidth"
+    android:padding="5dp"
+    android:text="@string/abort_action"
+    android:textColor="@android:color/white"
+    android:layout_alignParentBottom="true"
+    android:layout_toLeftOf="@+id/imageView"
+    android:layout_margin="1dp">
+    <!--Removed ObsoleteLayoutParam: layout_weight-->
+  </Button>
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_send_email.xml
+++ b/app/src/main/res/layout/fragment_send_email.xml
@@ -1,138 +1,126 @@
-<RelativeLayout  xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+<?xml version='1.0' encoding='UTF-8'?>
+  <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent">
 
-    <ScrollView
-        android:layout_width="wrap_content"
+  <ScrollView android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:id="@+id/scrollView9"
+    android:layout_alignParentLeft="true"
+    android:layout_alignParentStart="true"
+    android:layout_above="@+id/btnCancel"
+    android:layout_alignParentTop="true"
+    android:fillViewport="true"
+    android:layout_alignRight="@+id/btnProceed"
+    android:layout_alignEnd="@+id/btnProceed">
+
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:tools="http://schemas.android.com/tools"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:orientation="vertical"
+      android:padding="16dp"
+      tools:context=".ResultSendEmailActivity">
+
+      <TextView android:id="@+id/textLink"
+        android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:id="@+id/scrollView9"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:layout_above="@+id/btnCancel"
-        android:layout_alignParentTop="true"
-        android:fillViewport="true"
-        android:layout_alignRight="@+id/btnProceed"
-        android:layout_alignEnd="@+id/btnProceed">
+        android:text="@string/description_send_email"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:textSize="15sp"/>
 
-        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-            xmlns:tools="http://schemas.android.com/tools"
+      <TableLayout android:id="@+id/tableLayout1"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp">
+
+        <TableRow android:id="@+id/tableRow1"
+          android:layout_width="fill_parent"
+          android:layout_height="wrap_content">
+
+          <TextView android:id="@+id/textResultSendEmailTo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingRight="8dp"
+            android:text="@string/to"
+            android:textStyle="bold"/>
+
+          <TextView android:id="@+id/textResultSendEmailAdress"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="reciept"
+            android:textIsSelectable="true"/>
+        </TableRow>
+
+        <TableRow android:id="@+id/tableRow2"
+          android:layout_width="fill_parent"
+          android:layout_height="wrap_content">
+
+          <TextView android:id="@+id/textResultSendEmailSub"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingRight="8dp"
+            android:text="@string/subject"
+            android:textStyle="bold"/>
+
+          <TextView android:id="@+id/textResultSendEmailSubject"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical"
-            android:padding="16dp"
-            tools:context=".ResultSendEmailActivity" >
+            android:layout_height="wrap_content"
+            android:text="sub"
+            android:textIsSelectable="true"/>
+        </TableRow>
+        <!--Removed ObsoleteLayoutParam: layout_below-->
+      </TableLayout>
 
-            <TextView
-                android:id="@+id/textLink"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/description_send_email"
-                android:textAppearance="?android:attr/textAppearanceMedium"
-                android:textSize="15sp" />
-
-            <TableLayout
-                android:id="@+id/tableLayout1"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:layout_below="@id/textLink"
-                android:layout_marginTop="20dp" >
-
-                <TableRow
-                    android:id="@+id/tableRow1"
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content" >
-
-                    <TextView
-                        android:id="@+id/textResultSendEmailTo"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:paddingRight="8dp"
-                        android:text="@string/to"
-                        android:textStyle="bold" />
-
-                    <TextView
-                        android:id="@+id/textResultSendEmailAdress"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="reciept"
-                        android:textIsSelectable="true" />
-                </TableRow>
-
-                <TableRow
-                    android:id="@+id/tableRow2"
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content" >
-
-                    <TextView
-                        android:id="@+id/textResultSendEmailSub"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:paddingRight="8dp"
-                        android:text="@string/subject"
-                        android:textStyle="bold" />
-
-                    <TextView
-                        android:id="@+id/textResultSendEmailSubject"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:text="sub"
-                        android:textIsSelectable="true" />
-                </TableRow>
-
-            </TableLayout>
-
-            <ScrollView
-                android:id="@+id/scrollView1"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignLeft="@+id/tableLayout1"
-                android:layout_below="@+id/tableLayout1" >
-
-                <TextView
-                    android:id="@+id/textResultSendEmail"
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_centerInParent="true"
-                    android:maxHeight="175dp"
-                    android:maxLines="10"
-                    android:scrollbars="vertical"
-                    android:textIsSelectable="true" />
-            </ScrollView>
-        </LinearLayout>
-    </ScrollView>
-
-    <Button
-        android:id="@+id/btnProceed"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:background="@drawable/button_fullwidth"
-        android:padding="5dp"
-        android:text="@string/choose_action"
-        android:textColor="@android:color/white"
-        android:layout_alignParentBottom="true"
-        android:layout_toRightOf="@+id/imageView"
-        android:layout_margin="1dp" />
-
-    <ImageView
-        android:layout_centerInParent="true"
-        android:layout_height="fill_parent"
+      <ScrollView android:id="@+id/scrollView1"
         android:layout_width="wrap_content"
-        android:id="@+id/imageView"
-        android:paddingLeft="2dp"
-        android:visibility="invisible" />
+        android:layout_height="wrap_content">
 
-    <Button
-        android:id="@+id/btnCancel"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:background="@drawable/button_fullwidth"
-        android:padding="5dp"
-        android:text="@string/abort_action"
-        android:textColor="@android:color/white"
-        android:layout_alignParentBottom="true"
-        android:layout_toLeftOf="@+id/imageView"
-        android:layout_margin="1dp" />
+        <TextView android:id="@+id/textResultSendEmail"
+          android:layout_width="fill_parent"
+          android:layout_height="wrap_content"
+          android:maxHeight="175dp"
+          android:maxLines="10"
+          android:scrollbars="vertical"
+          android:textIsSelectable="true">
+          <!--Removed ObsoleteLayoutParam: layout_centerInParent-->
+        </TextView>
+        <!--Removed ObsoleteLayoutParam: layout_alignLeft-->
+        <!--Removed ObsoleteLayoutParam: layout_below-->
+      </ScrollView>
+    </LinearLayout>
+  </ScrollView>
 
+  <Button android:id="@+id/btnProceed"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/button_fullwidth"
+    android:padding="5dp"
+    android:text="@string/choose_action"
+    android:textColor="@android:color/white"
+    android:layout_alignParentBottom="true"
+    android:layout_toRightOf="@+id/imageView"
+    android:layout_margin="1dp">
+    <!--Removed ObsoleteLayoutParam: layout_weight-->
+  </Button>
+
+  <ImageView android:layout_centerInParent="true"
+    android:layout_height="fill_parent"
+    android:layout_width="wrap_content"
+    android:id="@+id/imageView"
+    android:paddingLeft="2dp"
+    android:visibility="invisible"/>
+
+  <Button android:id="@+id/btnCancel"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/button_fullwidth"
+    android:padding="5dp"
+    android:text="@string/abort_action"
+    android:textColor="@android:color/white"
+    android:layout_alignParentBottom="true"
+    android:layout_toLeftOf="@+id/imageView"
+    android:layout_margin="1dp">
+    <!--Removed ObsoleteLayoutParam: layout_weight-->
+  </Button>
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_sms.xml
+++ b/app/src/main/res/layout/fragment_sms.xml
@@ -1,93 +1,88 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<?xml version='1.0' encoding='UTF-8'?>
+  <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="fill_parent"
+  android:layout_height="fill_parent"
+  android:background="#FFFFFF"
+  android:orientation="vertical">
+
+  <ScrollView android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:id="@+id/scrollView2"
+    android:fillViewport="true"
+    android:layout_above="@+id/btnCancel"
+    android:layout_alignRight="@+id/btnProceed"
+    android:layout_alignEnd="@+id/btnProceed"
+    android:layout_alignParentLeft="true"
+    android:layout_alignParentStart="true"
+    android:layout_alignParentTop="true">
+
+    <LinearLayout android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+      android:orientation="vertical"
+      android:padding="16dp">
+
+      <TextView android:id="@+id/textLink"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/description_sms"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:textSize="15sp"/>
+
+      <TextView android:id="@+id/textResultSms"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="20dp"
+        android:autoLink="none"
+        android:gravity="center_horizontal"
+        android:textIsSelectable="true">
+        <!--Removed ObsoleteLayoutParam: layout_centerHorizontal-->
+        <!--Removed ObsoleteLayoutParam: layout_centerVertical-->
+      </TextView>
+
+      <TextView android:id="@+id/textContentSms"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="22dp"
+        android:gravity="center_horizontal"
+        android:textIsSelectable="true">
+        <!--Removed ObsoleteLayoutParam: layout_below-->
+        <!--Removed ObsoleteLayoutParam: layout_centerHorizontal-->
+      </TextView>
+    </LinearLayout>
+  </ScrollView>
+
+  <Button android:id="@+id/btnProceed"
     android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/button_fullwidth"
+    android:padding="5dp"
+    android:text="@string/choose_action"
+    android:textColor="@android:color/white"
+    android:layout_alignParentBottom="true"
+    android:layout_toRightOf="@+id/imageView"
+    android:layout_margin="1dp">
+    <!--Removed ObsoleteLayoutParam: layout_weight-->
+  </Button>
+
+  <ImageView android:layout_centerInParent="true"
     android:layout_height="fill_parent"
-    android:background="#FFFFFF"
-    android:orientation="vertical">
+    android:layout_width="wrap_content"
+    android:id="@+id/imageView"
+    android:paddingLeft="2dp"
+    android:visibility="invisible"/>
 
-    <ScrollView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@+id/scrollView2"
-        android:fillViewport="true"
-        android:layout_above="@+id/btnCancel"
-        android:layout_alignRight="@+id/btnProceed"
-        android:layout_alignEnd="@+id/btnProceed"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:layout_alignParentTop="true">
-
-        <LinearLayout
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:padding="16dp" >
-
-            <TextView
-                android:id="@+id/textLink"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/description_sms"
-                android:textAppearance="?android:attr/textAppearanceMedium"
-                android:textSize="15sp" />
-
-            <TextView
-                android:id="@+id/textResultSms"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_centerHorizontal="true"
-                android:layout_centerVertical="true"
-                android:layout_gravity="center_horizontal"
-                android:layout_marginTop="20dp"
-                android:autoLink="none"
-                android:gravity="center_horizontal"
-                android:textIsSelectable="true" />
-
-            <TextView
-                android:id="@+id/textContentSms"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_below="@+id/textResultSms"
-                android:layout_centerHorizontal="true"
-                android:layout_gravity="center_horizontal"
-                android:layout_marginTop="22dp"
-                android:gravity="center_horizontal"
-                android:textIsSelectable="true" />
-
-        </LinearLayout>
-    </ScrollView>
-
-    <Button
-        android:id="@+id/btnProceed"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:background="@drawable/button_fullwidth"
-        android:padding="5dp"
-        android:text="@string/choose_action"
-        android:textColor="@android:color/white"
-        android:layout_alignParentBottom="true"
-        android:layout_toRightOf="@+id/imageView"
-        android:layout_margin="1dp" />
-
-    <ImageView
-        android:layout_centerInParent="true"
-        android:layout_height="fill_parent"
-        android:layout_width="wrap_content"
-        android:id="@+id/imageView"
-        android:paddingLeft="2dp"
-        android:visibility="invisible" />
-
-    <Button
-        android:id="@+id/btnCancel"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:background="@drawable/button_fullwidth"
-        android:padding="5dp"
-        android:text="@string/abort_action"
-        android:textColor="@android:color/white"
-        android:layout_alignParentBottom="true"
-        android:layout_toLeftOf="@+id/imageView"
-        android:layout_margin="1dp" />
-
+  <Button android:id="@+id/btnCancel"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/button_fullwidth"
+    android:padding="5dp"
+    android:text="@string/abort_action"
+    android:textColor="@android:color/white"
+    android:layout_alignParentBottom="true"
+    android:layout_toLeftOf="@+id/imageView"
+    android:layout_margin="1dp">
+    <!--Removed ObsoleteLayoutParam: layout_weight-->
+  </Button>
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_tel.xml
+++ b/app/src/main/res/layout/fragment_tel.xml
@@ -1,79 +1,75 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<?xml version='1.0' encoding='UTF-8'?>
+  <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="fill_parent"
+  android:layout_height="fill_parent"
+  android:background="#FFFFFF"
+  android:orientation="vertical">
+
+  <ScrollView android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:id="@+id/scrollView3"
+    android:layout_above="@+id/btnProceed"
+    android:layout_alignParentTop="true"
+    android:fillViewport="true">
+
+    <LinearLayout android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+      android:orientation="vertical"
+      android:padding="16dp">
+
+      <TextView android:id="@+id/textLink"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/description_tel"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:textSize="15sp"/>
+
+      <TextView android:id="@+id/result_field_tel"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignWithParentIfMissing="true"
+        android:layout_marginTop="20dp"
+        android:gravity="center_vertical|center_horizontal"
+        android:text="Example application"
+        android:textSize="16sp"
+        android:textIsSelectable="true">
+        <!--Removed ObsoleteLayoutParam: layout_alignParentRight-->
+        <!--Removed ObsoleteLayoutParam: layout_alignParentTop-->
+        <!--Removed ObsoleteLayoutParam: layout_centerInParent-->
+      </TextView>
+    </LinearLayout>
+  </ScrollView>
+
+  <Button android:id="@+id/btnProceed"
     android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/button_fullwidth"
+    android:padding="5dp"
+    android:text="@string/choose_action"
+    android:textColor="@android:color/white"
+    android:layout_alignParentBottom="true"
+    android:layout_toRightOf="@+id/imageView"
+    android:layout_margin="1dp">
+    <!--Removed ObsoleteLayoutParam: layout_weight-->
+  </Button>
+
+  <ImageView android:layout_centerInParent="true"
     android:layout_height="fill_parent"
-    android:background="#FFFFFF"
-    android:orientation="vertical">
+    android:layout_width="wrap_content"
+    android:id="@+id/imageView"
+    android:paddingLeft="2dp"
+    android:visibility="invisible"/>
 
-    <ScrollView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@+id/scrollView3"
-        android:layout_above="@+id/btnProceed"
-        android:layout_alignParentTop="true"
-        android:fillViewport="true">
-
-        <LinearLayout
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:padding="16dp" >
-
-            <TextView
-                android:id="@+id/textLink"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/description_tel"
-                android:textAppearance="?android:attr/textAppearanceMedium"
-                android:textSize="15sp" />
-
-            <TextView
-                android:id="@+id/result_field_tel"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:layout_alignParentRight="true"
-                android:layout_alignParentTop="true"
-                android:layout_alignWithParentIfMissing="true"
-                android:layout_centerInParent="false"
-                android:layout_marginTop="20dp"
-                android:gravity="center_vertical|center_horizontal"
-                android:text="Example application"
-                android:textSize="16sp"
-                android:textIsSelectable="true" />
-
-        </LinearLayout>
-    </ScrollView>
-
-    <Button
-        android:id="@+id/btnProceed"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:background="@drawable/button_fullwidth"
-        android:padding="5dp"
-        android:text="@string/choose_action"
-        android:textColor="@android:color/white"
-        android:layout_alignParentBottom="true"
-        android:layout_toRightOf="@+id/imageView"
-        android:layout_margin="1dp" />
-
-    <ImageView
-        android:layout_centerInParent="true"
-        android:layout_height="fill_parent"
-        android:layout_width="wrap_content"
-        android:id="@+id/imageView"
-        android:paddingLeft="2dp"
-        android:visibility="invisible" />
-
-    <Button
-        android:id="@+id/btnCancel"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:background="@drawable/button_fullwidth"
-        android:padding="5dp"
-        android:text="@string/abort_action"
-        android:textColor="@android:color/white"
-        android:layout_alignParentBottom="true"
-        android:layout_toLeftOf="@+id/imageView"
-        android:layout_margin="1dp" />
+  <Button android:id="@+id/btnCancel"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/button_fullwidth"
+    android:padding="5dp"
+    android:text="@string/abort_action"
+    android:textColor="@android:color/white"
+    android:layout_alignParentBottom="true"
+    android:layout_toLeftOf="@+id/imageView"
+    android:layout_margin="1dp">
+    <!--Removed ObsoleteLayoutParam: layout_weight-->
+  </Button>
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_text.xml
+++ b/app/src/main/res/layout/fragment_text.xml
@@ -1,80 +1,75 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<?xml version='1.0' encoding='UTF-8'?>
+  <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="fill_parent"
+  android:layout_height="fill_parent"
+  android:background="#FFFFFF"
+  android:orientation="vertical">
+
+  <ScrollView android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:id="@+id/scrollView4"
+    android:layout_above="@+id/btnProceed"
+    android:layout_alignParentTop="true"
+    android:fillViewport="true">
+
+    <LinearLayout android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+      android:orientation="vertical"
+      android:padding="16dp">
+
+      <TextView android:id="@+id/textLink"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/description_text"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:textSize="15sp"/>
+
+      <TextView android:id="@+id/result_field_text"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignWithParentIfMissing="true"
+        android:layout_marginTop="20dp"
+        android:gravity="center_vertical|center_horizontal"
+        android:text="Example application"
+        android:textSize="16sp"
+        android:textIsSelectable="true">
+        <!--Removed ObsoleteLayoutParam: layout_alignParentRight-->
+        <!--Removed ObsoleteLayoutParam: layout_alignParentTop-->
+        <!--Removed ObsoleteLayoutParam: layout_centerInParent-->
+      </TextView>
+    </LinearLayout>
+  </ScrollView>
+
+  <Button android:id="@+id/btnProceed"
     android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/button_fullwidth"
+    android:padding="5dp"
+    android:text="@string/choose_action"
+    android:textColor="@android:color/white"
+    android:layout_alignParentBottom="true"
+    android:layout_toRightOf="@+id/imageView"
+    android:layout_margin="1dp">
+    <!--Removed ObsoleteLayoutParam: layout_weight-->
+  </Button>
+
+  <ImageView android:layout_centerInParent="true"
     android:layout_height="fill_parent"
-    android:background="#FFFFFF"
-    android:orientation="vertical">
+    android:layout_width="wrap_content"
+    android:id="@+id/imageView"
+    android:paddingLeft="2dp"
+    android:visibility="invisible"/>
 
-    <ScrollView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@+id/scrollView4"
-        android:layout_above="@+id/btnProceed"
-        android:layout_alignParentTop="true"
-        android:fillViewport="true">
-
-        <LinearLayout
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:padding="16dp" >
-
-            <TextView
-                android:id="@+id/textLink"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/description_text"
-                android:textAppearance="?android:attr/textAppearanceMedium"
-                android:textSize="15sp" />
-
-            <TextView
-                android:id="@+id/result_field_text"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:layout_alignParentRight="true"
-                android:layout_alignParentTop="true"
-                android:layout_alignWithParentIfMissing="true"
-                android:layout_centerInParent="false"
-                android:layout_marginTop="20dp"
-                android:gravity="center_vertical|center_horizontal"
-                android:text="Example application"
-                android:textSize="16sp"
-                android:textIsSelectable="true" />
-
-        </LinearLayout>
-    </ScrollView>
-
-    <Button
-        android:id="@+id/btnProceed"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:background="@drawable/button_fullwidth"
-        android:padding="5dp"
-        android:text="@string/choose_action"
-        android:textColor="@android:color/white"
-        android:layout_alignParentBottom="true"
-        android:layout_toRightOf="@+id/imageView"
-        android:layout_margin="1dp" />
-
-    <ImageView
-        android:layout_centerInParent="true"
-        android:layout_height="fill_parent"
-        android:layout_width="wrap_content"
-        android:id="@+id/imageView"
-        android:paddingLeft="2dp"
-        android:visibility="invisible" />
-
-    <Button
-        android:id="@+id/btnCancel"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:background="@drawable/button_fullwidth"
-        android:padding="5dp"
-        android:text="@string/abort_action"
-        android:textColor="@android:color/white"
-        android:layout_alignParentBottom="true"
-        android:layout_toLeftOf="@+id/imageView"
-        android:layout_margin="1dp" />
-
+  <Button android:id="@+id/btnCancel"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/button_fullwidth"
+    android:padding="5dp"
+    android:text="@string/abort_action"
+    android:textColor="@android:color/white"
+    android:layout_alignParentBottom="true"
+    android:layout_toLeftOf="@+id/imageView"
+    android:layout_margin="1dp">
+    <!--Removed ObsoleteLayoutParam: layout_weight-->
+  </Button>
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_url.xml
+++ b/app/src/main/res/layout/fragment_url.xml
@@ -1,99 +1,91 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<?xml version='1.0' encoding='UTF-8'?>
+  <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="fill_parent"
+  android:layout_height="fill_parent"
+  android:background="#FFFFFF"
+  android:orientation="vertical">
+
+  <ScrollView android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:id="@+id/scrollView"
+    android:nestedScrollingEnabled="false"
+    android:fillViewport="true"
+    android:layout_above="@+id/btnProceed"
+    android:layout_alignParentTop="true">
+
+    <LinearLayout android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+      android:orientation="vertical"
+      android:padding="16dp">
+
+      <TextView android:id="@+id/hints4"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/urlExplanation"
+        android:textSize="15sp"
+        android:textStyle="normal"/>
+
+      <TextView android:id="@+id/textDomain"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="15dp"
+        android:gravity="center_horizontal"
+        android:text="@string/domain"
+        android:textSize="15sp"
+        android:textIsSelectable="true"/>
+
+      <CheckBox android:id="@+id/checkBoxKnowRisks"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="15dp"
+        android:checked="false"
+        android:longClickable="false"
+        android:text="@string/knowRisks"
+        android:textSize="15sp"/>
+
+      <TextView android:id="@+id/textLink"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="15dp"
+        android:text="@string/further_info"
+        android:textSize="15sp"
+        android:linksClickable="true"
+        android:enabled="true"
+        android:clickable="true"
+        android:focusable="true"/>
+    </LinearLayout>
+  </ScrollView>
+
+  <Button android:id="@+id/btnProceed"
     android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/button_fullwidth"
+    android:padding="5dp"
+    android:text="@string/choose_action"
+    android:textColor="@android:color/white"
+    android:layout_alignParentBottom="true"
+    android:layout_toRightOf="@+id/imageView"
+    android:layout_margin="1dp">
+    <!--Removed ObsoleteLayoutParam: layout_weight-->
+  </Button>
+
+  <ImageView android:layout_centerInParent="true"
     android:layout_height="fill_parent"
-    android:background="#FFFFFF"
-    android:orientation="vertical">
+    android:layout_width="wrap_content"
+    android:id="@+id/imageView"
+    android:paddingLeft="2dp"
+    android:visibility="invisible"/>
 
-    <ScrollView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@+id/scrollView"
-        android:nestedScrollingEnabled="false"
-        android:fillViewport="true"
-        android:layout_above="@+id/btnProceed"
-        android:layout_alignParentTop="true">
-
-        <LinearLayout
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:padding="16dp" >
-
-            <TextView
-                android:id="@+id/hints4"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/urlExplanation"
-                android:textSize="15sp"
-                android:textStyle="normal" />
-
-            <TextView
-                android:id="@+id/textDomain"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="15dp"
-                android:gravity="center_horizontal"
-                android:text="@string/domain"
-                android:textSize="15sp"
-                android:textIsSelectable="true" />
-
-            <CheckBox
-                android:id="@+id/checkBoxKnowRisks"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="15dp"
-                android:checked="false"
-                android:longClickable="false"
-                android:text="@string/knowRisks"
-                android:textSize="15sp" />
-
-            <TextView
-                android:id="@+id/textLink"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="15dp"
-                android:text="@string/further_info"
-                android:textSize="15sp"
-                android:linksClickable="true"
-                android:enabled="true"
-                android:clickable="true"
-                android:focusable="true" />
-
-        </LinearLayout>
-    </ScrollView>
-
-    <Button
-        android:id="@+id/btnProceed"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:background="@drawable/button_fullwidth"
-        android:padding="5dp"
-        android:text="@string/choose_action"
-        android:textColor="@android:color/white"
-        android:layout_alignParentBottom="true"
-        android:layout_toRightOf="@+id/imageView"
-        android:layout_margin="1dp" />
-
-    <ImageView
-        android:layout_centerInParent="true"
-        android:layout_height="fill_parent"
-        android:layout_width="wrap_content"
-        android:id="@+id/imageView"
-        android:paddingLeft="2dp"
-        android:visibility="invisible" />
-
-    <Button
-        android:id="@+id/btnCancel"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:background="@drawable/button_fullwidth"
-        android:padding="5dp"
-        android:text="@string/abort_action"
-        android:textColor="@android:color/white"
-        android:layout_alignParentBottom="true"
-        android:layout_toLeftOf="@+id/imageView"
-        android:layout_margin="1dp" />
-
+  <Button android:id="@+id/btnCancel"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/button_fullwidth"
+    android:padding="5dp"
+    android:text="@string/abort_action"
+    android:textColor="@android:color/white"
+    android:layout_alignParentBottom="true"
+    android:layout_toLeftOf="@+id/imageView"
+    android:layout_margin="1dp">
+    <!--Removed ObsoleteLayoutParam: layout_weight-->
+  </Button>
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_wifi.xml
+++ b/app/src/main/res/layout/fragment_wifi.xml
@@ -1,92 +1,84 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<?xml version='1.0' encoding='UTF-8'?>
+  <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="fill_parent"
+  android:layout_height="fill_parent"
+  android:background="#FFFFFF"
+  android:orientation="vertical">
+
+  <ScrollView android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:id="@+id/scrollView5"
+    android:layout_above="@+id/btnProceed"
+    android:layout_alignParentTop="true"
+    android:fillViewport="true"
+    android:layout_alignRight="@+id/btnProceed"
+    android:layout_alignEnd="@+id/btnProceed"
+    android:layout_alignParentLeft="true"
+    android:layout_alignParentStart="true">
+
+    <LinearLayout android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+      android:orientation="vertical"
+      android:padding="16dp">
+
+      <TextView android:id="@+id/result_field_wifi_exlanation"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/wifi_explanation"
+        android:textSize="15sp"
+        android:textStyle="normal"/>
+
+      <TextView android:id="@+id/result_field_wifi"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:gravity="center_vertical|center_horizontal"
+        android:textSize="16sp"
+        android:textIsSelectable="true"/>
+
+      <TextView android:id="@+id/result_field_wifi_encryption"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical|center_horizontal"/>
+
+      <TextView android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/result_field_wifi_pw"
+        android:gravity="center_horizontal"
+        android:textIsSelectable="true"/>
+    </LinearLayout>
+  </ScrollView>
+
+  <Button android:id="@+id/btnProceed"
     android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/button_fullwidth"
+    android:padding="5dp"
+    android:text="@string/choose_action"
+    android:textColor="@android:color/white"
+    android:layout_alignParentBottom="true"
+    android:layout_toRightOf="@+id/imageView"
+    android:layout_margin="1dp">
+    <!--Removed ObsoleteLayoutParam: layout_weight-->
+  </Button>
+
+  <ImageView android:layout_centerInParent="true"
     android:layout_height="fill_parent"
-    android:background="#FFFFFF"
-    android:orientation="vertical">
+    android:layout_width="wrap_content"
+    android:id="@+id/imageView"
+    android:paddingLeft="2dp"
+    android:visibility="invisible"/>
 
-    <ScrollView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@+id/scrollView5"
-        android:layout_above="@+id/btnProceed"
-        android:layout_alignParentTop="true"
-        android:fillViewport="true"
-        android:layout_alignRight="@+id/btnProceed"
-        android:layout_alignEnd="@+id/btnProceed"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true">
-
-        <LinearLayout
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:padding="16dp" >
-
-            <TextView
-                android:id="@+id/result_field_wifi_exlanation"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/wifi_explanation"
-                android:textSize="15sp"
-                android:textStyle="normal" />
-
-            <TextView
-                android:id="@+id/result_field_wifi"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="10dp"
-                android:gravity="center_vertical|center_horizontal"
-                android:textSize="16sp"
-                android:textIsSelectable="true" />
-
-            <TextView
-                android:id="@+id/result_field_wifi_encryption"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center_vertical|center_horizontal" />
-
-            <TextView
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:id="@+id/result_field_wifi_pw"
-                android:gravity="center_horizontal"
-                android:textIsSelectable="true" />
-
-        </LinearLayout>
-    </ScrollView>
-
-    <Button
-        android:id="@+id/btnProceed"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:background="@drawable/button_fullwidth"
-        android:padding="5dp"
-        android:text="@string/choose_action"
-        android:textColor="@android:color/white"
-        android:layout_alignParentBottom="true"
-        android:layout_toRightOf="@+id/imageView"
-        android:layout_margin="1dp" />
-
-    <ImageView
-        android:layout_centerInParent="true"
-        android:layout_height="fill_parent"
-        android:layout_width="wrap_content"
-        android:id="@+id/imageView"
-        android:paddingLeft="2dp"
-        android:visibility="invisible" />
-
-    <Button
-        android:id="@+id/btnCancel"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:background="@drawable/button_fullwidth"
-        android:padding="5dp"
-        android:text="@string/abort_action"
-        android:textColor="@android:color/white"
-        android:layout_alignParentBottom="true"
-        android:layout_toLeftOf="@+id/imageView"
-        android:layout_margin="1dp" />
-
+  <Button android:id="@+id/btnCancel"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/button_fullwidth"
+    android:padding="5dp"
+    android:text="@string/abort_action"
+    android:textColor="@android:color/white"
+    android:layout_alignParentBottom="true"
+    android:layout_toLeftOf="@+id/imageView"
+    android:layout_margin="1dp">
+    <!--Removed ObsoleteLayoutParam: layout_weight-->
+  </Button>
 </RelativeLayout>


### PR DESCRIPTION
Hi,

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "ObsoleteLayoutParam".

While developing your application's views you might be specifying attributes in a view's artefact that are not necessary due to the nature of its parent. In this PR, those attributes were replaced by a comment.

I have made a previous validation of the changes and they seem correct.
Unfortunately, this tool is not able keep the original whitespace of the files, so comparison without ignoring whitespace might be confusing.
Please consider the changes and let me know if you agree with them.

Best,
Luis