### PR TITLE
Fix aztec encoding #76

### DIFF
--- a/app/src/main/java/com/secuso/privacyFriendlyCodeScanner/qrscanner/helpers/Utils.java
+++ b/app/src/main/java/com/secuso/privacyFriendlyCodeScanner/qrscanner/helpers/Utils.java
@@ -30,7 +30,7 @@ public class Utils {
                 hints.put(ERROR_CORRECTION, ec);
             }
         }
-        if(!hints.containsKey(ERROR_CORRECTION)) {
+        if(!hints.containsKey(ERROR_CORRECTION) && format!=BarcodeFormat.AZTEC) {
             hints.put(ERROR_CORRECTION, ErrorCorrectionLevel.L.name());
         }
 


### PR DESCRIPTION
Fixes #76 
High probability that it also fixes #67 (no hints how to reproduce the error given)

The app crashes during writing/encoding the decoded content for the history.
AztecWriter from ZING is reading the attribut ERROR_CORRECTION in a wrong way, so it is partly a bug of zxing. However this attribut should never be added passed on to the aztec reader.