### PR TITLE
Fix #104: Recognize prepending http / https case insensitive

### DIFF
--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/resultfragments/URLResultFragment.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/resultfragments/URLResultFragment.java
@@ -92,7 +92,8 @@ public class URLResultFragment extends ResultFragment {
         } else {
             String caption = "";
             String qrurl3="";
-            if(!qrurl.startsWith("http://") && !qrurl.startsWith("https://"))
+            final String lowercase_qrurl = qrurl.toLowerCase();
+            if(!lowercase_qrurl.startsWith("http://") && !lowercase_qrurl.startsWith("https://"))
             {
                 qrurl3 = "http://" + qrurl;
 


### PR DESCRIPTION
Should fix #104

Converting whole url/uri to lower case is no option, some servers handle them case sensitive.