### PR TITLE
#107 Prevent NullPointerException and show Toast instead

### DIFF
--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/activities/generator/MailEnterActivity.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/activities/generator/MailEnterActivity.java
@@ -6,6 +6,7 @@ import android.text.InputFilter;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -19,30 +20,26 @@ public class MailEnterActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_mail_enter);
 
-        final EditText qrResult=(EditText) findViewById(R.id.editMail);
-        Button generate=(Button) findViewById(R.id.generate);
+        final EditText qrResult = (EditText) findViewById(R.id.editMail);
+        Button generate = (Button) findViewById(R.id.generate);
 
         int maxLength = 50;
-        qrResult.setFilters(new InputFilter[] {new InputFilter.LengthFilter(maxLength)});
+        qrResult.setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxLength)});
 
         generate.setOnClickListener(new View.OnClickListener() {
             String result;
+
             @Override
             public void onClick(View v) {
-
-
-
-
-
-                    result = qrResult.getText().toString();
-                    Intent i = new Intent(MailEnterActivity.this, QrGeneratorDisplayActivity.class);
-                    i.putExtra("gn", result);
-                    i.putExtra("type", Contents.Type.EMAIL);
-                    startActivity(i);
-
-
-
-
+                result = qrResult.getText().toString();
+                if (result.isEmpty()) {
+                    Toast.makeText(MailEnterActivity.this, R.string.activity_enter_toast_missing_data, Toast.LENGTH_SHORT).show();
+                    return;
+                }
+                Intent i = new Intent(MailEnterActivity.this, QrGeneratorDisplayActivity.class);
+                i.putExtra("gn", result);
+                i.putExtra("type", Contents.Type.EMAIL);
+                startActivity(i);
             }
 
         });

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/activities/generator/MarketEnterActivity.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/activities/generator/MarketEnterActivity.java
@@ -6,6 +6,7 @@ import android.text.InputFilter;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -19,17 +20,21 @@ public class MarketEnterActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_market_enter);
 
-        final EditText qrMarket=(EditText) findViewById(R.id.editText);
-        Button generate=(Button) findViewById(R.id.generate);
+        final EditText qrMarket = (EditText) findViewById(R.id.editText);
+        Button generate = (Button) findViewById(R.id.generate);
 
         int maxLength = 75;
-        qrMarket.setFilters(new InputFilter[] {new InputFilter.LengthFilter(maxLength)});
+        qrMarket.setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxLength)});
         generate.setOnClickListener(new View.OnClickListener() {
             String result;
+
             @Override
             public void onClick(View v) {
-
                 result = qrMarket.getText().toString();
+                if (result.isEmpty()) {
+                    Toast.makeText(MarketEnterActivity.this, R.string.activity_enter_toast_missing_data, Toast.LENGTH_SHORT).show();
+                    return;
+                }
                 Intent i = new Intent(MarketEnterActivity.this, QrGeneratorDisplayActivity.class);
                 i.putExtra("gn", result);
                 i.putExtra("type", Contents.Type.Market);

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/activities/generator/TelEnterActivity.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/activities/generator/TelEnterActivity.java
@@ -6,6 +6,7 @@ import android.text.InputFilter;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -19,29 +20,26 @@ public class TelEnterActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_tel_enter);
 
-        final EditText qrResult=(EditText) findViewById(R.id.editPhone);
-        Button generate=(Button) findViewById(R.id.generate);
+        final EditText qrResult = (EditText) findViewById(R.id.editPhone);
+        Button generate = (Button) findViewById(R.id.generate);
 
         int maxLength = 15;
-        qrResult.setFilters(new InputFilter[] {new InputFilter.LengthFilter(maxLength)});
+        qrResult.setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxLength)});
 
         generate.setOnClickListener(new View.OnClickListener() {
             String result;
+
             @Override
             public void onClick(View v) {
-
-
-
-
                 result = qrResult.getText().toString();
+                if (result.isEmpty()) {
+                    Toast.makeText(TelEnterActivity.this, R.string.activity_enter_toast_missing_data, Toast.LENGTH_SHORT).show();
+                    return;
+                }
                 Intent i = new Intent(TelEnterActivity.this, QrGeneratorDisplayActivity.class);
                 i.putExtra("gn", result);
                 i.putExtra("type", Contents.Type.PHONE);
                 startActivity(i);
-
-
-
-
             }
 
         });

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/activities/generator/TextEnterActivity.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/activities/generator/TextEnterActivity.java
@@ -6,6 +6,7 @@ import android.text.InputFilter;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -19,17 +20,21 @@ public class TextEnterActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_text_enter);
 
-        final EditText qrText=(EditText) findViewById(R.id.editText);
-        Button generate=(Button) findViewById(R.id.generate);
+        final EditText qrText = (EditText) findViewById(R.id.editText);
+        Button generate = (Button) findViewById(R.id.generate);
 
         int maxLength = 75;
-        qrText.setFilters(new InputFilter[] {new InputFilter.LengthFilter(maxLength)});
+        qrText.setFilters(new InputFilter[]{new InputFilter.LengthFilter(maxLength)});
         generate.setOnClickListener(new View.OnClickListener() {
             String result;
+
             @Override
             public void onClick(View v) {
-
                 result = qrText.getText().toString();
+                if (result.isEmpty()) {
+                    Toast.makeText(TextEnterActivity.this, R.string.activity_enter_toast_missing_data, Toast.LENGTH_SHORT).show();
+                    return;
+                }
                 Intent i = new Intent(TextEnterActivity.this, QrGeneratorDisplayActivity.class);
                 i.putExtra("gn", result);
                 i.putExtra("type", Contents.Type.TEXT);

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/activities/generator/UrlEnterActivity.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/activities/generator/UrlEnterActivity.java
@@ -6,6 +6,7 @@ import android.text.InputFilter;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -30,6 +31,10 @@ public class UrlEnterActivity extends AppCompatActivity {
             @Override
             public void onClick(View v) {
                 result = qrResult.getText().toString();
+                if (result.isEmpty()) {
+                    Toast.makeText(UrlEnterActivity.this, R.string.activity_enter_toast_missing_data, Toast.LENGTH_SHORT).show();
+                    return;
+                }
                 Intent i = new Intent(UrlEnterActivity.this, QrGeneratorDisplayActivity.class);
                 i.putExtra("gn", result);
                 i.putExtra("type", Contents.Type.WEB_URL);

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -262,6 +262,7 @@
     <string name="item_result_email_subject">Titel:</string>
     <string name="item_result_email_to">Empfänger:</string>
     <string name="activity_result_toast_error_cant_load">Ein Fehler ist beim Laden des Codes aufgetreten.</string>
+    <string name="activity_enter_toast_missing_data">Keine Daten</string>
 
     <string name="text_enter">Der Text, den Sie codieren möchten</string>
     <string name="hello_world">Hallo Welt</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -270,6 +270,7 @@
     <string name="activity_result_toast_saved">Salvato nella cronologia.</string>
     <string name="fragment_result_product_label">Identificatore:</string>
     <string name="activity_result_toast_error_cant_load">Qualcosa è andato storto durante il caricamento del risultato.</string>
+    <string name="activity_enter_toast_missing_data">Nessun dato</string>
     <string-array name="pref_search_engine_entries">
         <item>DuckDuckGo</item>
         <item>Google</item>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -270,6 +270,7 @@
     <string name="activity_result_toast_saved">Opgeslagen in de geschiedenis.</string>
     <string name="fragment_result_product_label">Identificatie:</string>
     <string name="activity_result_toast_error_cant_load">Er is iets misgegaan tijdens het laden van het resultaat.</string>
+    <string name="activity_enter_toast_missing_data">Geen gegevens</string>
 
     <string name="text_enter">De tekst die u wilt coderen</string>
     <string name="hello_world">Hallo Wereld</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -285,6 +285,7 @@
     <string name="activity_result_toast_saved">Saved to history.</string>
     <string name="fragment_result_product_label">Identifier:</string>
     <string name="activity_result_toast_error_cant_load">Something went wrong when loading the result.</string>
+    <string name="activity_enter_toast_missing_data">No data</string>
     <string-array name="pref_search_engine_entries">
         <item>DuckDuckGo</item>
         <item>Google</item>


### PR DESCRIPTION
This fixes issue #107 by not creating a QR code and not launching the result activity when there is no data entered. That would lead to a NullPointerException. Instead a toast is shown, saying there is no data

Privacy