### PR TITLE
add setting to (not) require link confirmation before opening

### DIFF
--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/resultfragments/URLResultFragment.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/resultfragments/URLResultFragment.java
@@ -2,9 +2,11 @@ package com.secuso.privacyfriendlycodescanner.qrscanner.ui.resultfragments;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.net.Uri;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.Spanned;
@@ -30,6 +32,7 @@ public class URLResultFragment extends ResultFragment {
 
     private boolean checked = false;
     private final boolean trust = false;
+    private SharedPreferences preferences;
     private String qrurl;
 
     public URLResultFragment() {
@@ -70,13 +73,17 @@ public class URLResultFragment extends ResultFragment {
 
         resultText.setText(WordtoSpan);
 
+        preferences = PreferenceManager.getDefaultSharedPreferences(getContext());
+
         // checked = trust = getBoolean("trust", false);
 
         final CheckBox knowDomain = (CheckBox) v.findViewById(R.id.checkBoxKnowRisks);
 
         // wenn bereits vertraut wurde, checkbox setzen
-        if(trust)
+        if (trust || !preferences.getBoolean("pref_require_link_confirmation", true)) {
             knowDomain.setChecked(true);
+            checked = true;
+        }
 
         knowDomain.setOnClickListener(v1 -> checked = knowDomain.isChecked());
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -271,6 +271,8 @@
     </string>
     <string name="pref_enable_beep_on_scan_title">Beep on scan</string>
     <string name="pref_enable_beep_on_scan_summary">Play a confirmation tone when scanning</string>
+    <string name="pref_require_link_confirmation_title">Link confirmation</string>
+    <string name="pref_require_link_confirmation_summary">Require confirmation before opening a link</string>
     <string name="activity_history_list_item_qr_image_descriptor" translatable="false">QR Code</string>
     <string name="delete">delete</string>
     <string name="dialog_history_delete_message">Do you really want to delete this entry?</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -34,4 +34,10 @@
             android:summary="@string/pref_enable_beep_on_scan_summary"
             android:title="@string/pref_enable_beep_on_scan_title" />
 
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="pref_require_link_confirmation"
+            android:summary="@string/pref_require_link_confirmation_title"
+            android:title="@string/pref_require_link_confirmation_summary" />
+
 </PreferenceScreen>


### PR DESCRIPTION
Addresses issues #23 by introducing settings to control if confirmation of each link is required.