### PR TITLE
Add option to choose code format and error correction level during generation

### DIFF
--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/generator/QRCodeEncoder.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/generator/QRCodeEncoder.java
@@ -58,14 +58,10 @@ public class QRCodeEncoder {
                 // Ignore it then
             }
         }
-        if (format == null || format == BarcodeFormat.QR_CODE) {
+        if (format == null) {
             this.format = BarcodeFormat.QR_CODE;
-            encodeQRCodeContents(data, bundle, type);
-        } else if (data != null && data.length() > 0) {
-            contents = data;
-            displayContents = data;
-            title = "Text";
         }
+        encodeQRCodeContents(data, bundle, type);
         return contents != null && contents.length() > 0;
     }
 

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/generator/QRCodeEncoder.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/generator/QRCodeEncoder.java
@@ -258,6 +258,9 @@ public class QRCodeEncoder {
         if(format.equals(BarcodeFormat.QR_CODE) || format.equals(BarcodeFormat.AZTEC) || format.equals(BarcodeFormat.PDF_417)) {
             hints.put(EncodeHintType.ERROR_CORRECTION, errorCorrectionLevel);
         }
+        if (format.equals(BarcodeFormat.QR_CODE) || format.equals(BarcodeFormat.PDF_417) || format.equals(BarcodeFormat.CODE_128)) {
+            hints.put(EncodeHintType.MARGIN, 0);
+        }
         MultiFormatWriter writer = new MultiFormatWriter();
         BitMatrix result = writer.encode(contents, format, dimension, dimension, hints);
         int width = result.getWidth();

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/generator/QRCodeEncoder.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/generator/QRCodeEncoder.java
@@ -247,14 +247,16 @@ public class QRCodeEncoder {
         }
     }
 
-    public Bitmap encodeAsBitmap() throws WriterException {
+    public Bitmap encodeAsBitmap(String errorCorrectionLevel) throws WriterException {
         if (!encoded) return null;
 
-        Map<EncodeHintType, Object> hints = null;
+        Map<EncodeHintType, Object> hints = new EnumMap<EncodeHintType, Object>(EncodeHintType.class);
         String encoding = guessAppropriateEncoding(contents);
         if (encoding != null) {
-            hints = new EnumMap<EncodeHintType, Object>(EncodeHintType.class);
             hints.put(EncodeHintType.CHARACTER_SET, encoding);
+        }
+        if(format.equals(BarcodeFormat.QR_CODE) || format.equals(BarcodeFormat.AZTEC) || format.equals(BarcodeFormat.PDF_417)) {
+            hints.put(EncodeHintType.ERROR_CORRECTION, errorCorrectionLevel);
         }
         MultiFormatWriter writer = new MultiFormatWriter();
         BitMatrix result = writer.encode(contents, format, dimension, dimension, hints);

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/generator/QRGeneratorUtils.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/generator/QRGeneratorUtils.java
@@ -22,6 +22,7 @@ import androidx.core.content.FileProvider;
 
 import com.google.zxing.BarcodeFormat;
 import com.google.zxing.WriterException;
+import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -69,6 +70,9 @@ public class QRGeneratorUtils {
     }
 
     public static Uri cacheImage(Context context, Bitmap image) {
+        if (image == null) {
+            throw new IllegalArgumentException("Image must not be null");
+        }
         File imageFilePath = new File(context.getCacheDir(), "images/");
         imageFilePath.mkdir();
         imageFilePath = new File(imageFilePath, buildFileString());
@@ -81,7 +85,7 @@ public class QRGeneratorUtils {
         return cache;
     }
 
-    public static Uri createImage(Context context, String qrInputText, Contents.Type qrType) {
+    public static Uri createImage(Context context, String qrInputText, Contents.Type qrType, BarcodeFormat barcodeFormat, String errorCorrectionLevel) {
 
         //Find screen size
         WindowManager manager = (WindowManager) context.getSystemService(WINDOW_SERVICE);
@@ -97,11 +101,11 @@ public class QRGeneratorUtils {
         QRCodeEncoder qrCodeEncoder = new QRCodeEncoder(qrInputText,
                 null,
                 qrType,
-                BarcodeFormat.QR_CODE.toString(),
+                barcodeFormat.toString(),
                 smallerDimension);
         Bitmap bitmap_ = null;
         try {
-            bitmap_ = qrCodeEncoder.encodeAsBitmap();
+            bitmap_ = qrCodeEncoder.encodeAsBitmap(errorCorrectionLevel);
             // return bitmap_;
 
         } catch (WriterException e) {

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/activities/generator/QrGeneratorDisplayActivity.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/activities/generator/QrGeneratorDisplayActivity.java
@@ -1,38 +1,66 @@
 package com.secuso.privacyfriendlycodescanner.qrscanner.ui.activities.generator;
 
 import android.Manifest;
-import android.content.ClipData;
-import android.content.ClipboardManager;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
+import android.widget.ArrayAdapter;
+import android.widget.AutoCompleteTextView;
 import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.content.res.AppCompatResources;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 
 import com.bumptech.glide.Glide;
+import com.google.android.material.textfield.TextInputLayout;
+import com.google.zxing.BarcodeFormat;
+import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel;
 import com.secuso.privacyfriendlycodescanner.qrscanner.R;
 import com.secuso.privacyfriendlycodescanner.qrscanner.generator.Contents;
 import com.secuso.privacyfriendlycodescanner.qrscanner.generator.QRGeneratorUtils;
 import com.secuso.privacyfriendlycodescanner.qrscanner.ui.activities.ScannerActivity;
+import com.secuso.privacyfriendlycodescanner.qrscanner.ui.helpers.IconArrayAdapter;
+
+import java.util.Arrays;
 
 public class QrGeneratorDisplayActivity extends AppCompatActivity {
 
     private static final int PERMISSION_WRITE_EXTERNAL_STORAGE_REQUEST = 0;
 
-    ClipboardManager clipboardManager;
-    ClipData clipData;
-
     String qrInputText = "";
     Contents.Type qrInputType = Contents.Type.UNDEFINED;
+
+    private final String[] barcodeFormats = new String[]{
+            BarcodeFormat.QR_CODE.name(),
+            BarcodeFormat.AZTEC.name(),
+            BarcodeFormat.DATA_MATRIX.name(),
+            BarcodeFormat.PDF_417.name(),
+            BarcodeFormat.CODE_128.name()};
+    private final Integer[] barcodeFormatIcons = new Integer[]{
+            R.drawable.ic_baseline_qr_code_24dp,
+            R.drawable.ic_aztec_code_24dp,
+            R.drawable.ic_data_matrix_code_24dp,
+            R.drawable.ic_pdf_417_code_24dp,
+            R.drawable.ic_barcode_24dp};
+    private AutoCompleteTextView dropdownMenuBarcodeFormat;
+    private BarcodeFormat barcodeFormat = BarcodeFormat.QR_CODE;
+    private BarcodeFormat lastFormat = barcodeFormat;
+
+    private final String[] errorCorrectionsQR = new String[]{ErrorCorrectionLevel.L.name(), ErrorCorrectionLevel.M.name(), ErrorCorrectionLevel.Q.name(), ErrorCorrectionLevel.H.name()};
+    private final String[] errorCorrectionsAztec = new String[]{"25", "50", "75", "90"};
+    private final String[] errorCorrectionsPDF417 = new String[]{"0", "1", "2", "3", "4", "5", "6", "7", "8"};
+    private ArrayAdapter<String> dropdownAdapterErrorCorrection;
+    private AutoCompleteTextView dropdownMenuErrorCorrection;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -40,7 +68,25 @@ public class QrGeneratorDisplayActivity extends AppCompatActivity {
         setContentView(R.layout.activity_qr_generator_display);
 
         Button btnstore = findViewById(R.id.btnStore);
-        ImageView myImage = findViewById(R.id.resultQRCodeImage);
+
+        dropdownMenuBarcodeFormat = findViewById(R.id.editBarcodeFormat);
+        IconArrayAdapter dropdownAdapterBarcodeFormat = new IconArrayAdapter(this, R.layout.list_item_generator, barcodeFormats, barcodeFormatIcons);
+        dropdownMenuBarcodeFormat.setAdapter(dropdownAdapterBarcodeFormat);
+        dropdownMenuBarcodeFormat.setText(barcodeFormats[0], false);
+        dropdownMenuBarcodeFormat.setAdapter(dropdownAdapterBarcodeFormat);
+
+
+        dropdownMenuBarcodeFormat.setOnItemClickListener((parent, view, position, id) -> generateAndUpdateImage());
+
+        dropdownMenuErrorCorrection = findViewById(R.id.editErrorCorrection);
+        dropdownAdapterErrorCorrection = new ArrayAdapter<>(QrGeneratorDisplayActivity.this, android.R.layout.simple_spinner_item, errorCorrectionsQR);
+        dropdownAdapterErrorCorrection.setDropDownViewResource(android.R.layout.simple_dropdown_item_1line);
+        dropdownMenuErrorCorrection.setAdapter(dropdownAdapterErrorCorrection);
+        dropdownMenuErrorCorrection.setText(errorCorrectionsQR[0], false);
+        dropdownMenuErrorCorrection.setAdapter(dropdownAdapterErrorCorrection);
+
+        dropdownMenuErrorCorrection.setOnItemClickListener((adapterView, view, i, l) -> generateAndUpdateImage());
+
 
         Bundle QRData = getIntent().getExtras();//from QRGenerator
         qrInputText = QRData.getString("gn");
@@ -48,7 +94,7 @@ public class QrGeneratorDisplayActivity extends AppCompatActivity {
 
         setTitle(qrInputType.toLocalizedString(getApplicationContext()));
 
-        Glide.with(this).load(QRGeneratorUtils.createImage(this, qrInputText, qrInputType)).into(myImage);
+        generateAndUpdateImage();
 
         btnstore.setOnClickListener(view -> {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
@@ -61,6 +107,50 @@ public class QrGeneratorDisplayActivity extends AppCompatActivity {
                 saveImageToStorage();
             }
         });
+    }
+
+    private void generateAndUpdateImage() {
+        ImageView myImage = findViewById(R.id.resultQRCodeImage);
+        TextInputLayout errorCorrectionLayout = findViewById(R.id.editErrorCorrectionInputLayout);
+
+        barcodeFormat = BarcodeFormat.valueOf(dropdownMenuBarcodeFormat.getText().toString());
+
+        if (!barcodeFormat.equals(lastFormat)) {
+            //format has changed
+            lastFormat = barcodeFormat;
+            String[] errorCorrectionOptions = null;
+            if (barcodeFormat.equals(BarcodeFormat.QR_CODE)) {
+                errorCorrectionOptions = errorCorrectionsQR;
+            } else if (barcodeFormat.equals(BarcodeFormat.AZTEC)) {
+                errorCorrectionOptions = errorCorrectionsAztec;
+            } else if (barcodeFormat.equals(BarcodeFormat.PDF_417)) {
+                errorCorrectionOptions = errorCorrectionsPDF417;
+            }
+
+            //only show error correction input field if the selected format supports error correction
+            if (errorCorrectionOptions == null) {
+                errorCorrectionLayout.setVisibility(View.INVISIBLE);
+            } else {
+                errorCorrectionLayout.setVisibility(View.VISIBLE);
+                dropdownAdapterErrorCorrection = new ArrayAdapter<>(QrGeneratorDisplayActivity.this, android.R.layout.simple_spinner_item, errorCorrectionOptions);
+                dropdownAdapterErrorCorrection.setDropDownViewResource(android.R.layout.simple_dropdown_item_1line);
+                dropdownMenuErrorCorrection.setAdapter(dropdownAdapterErrorCorrection);
+                dropdownMenuErrorCorrection.setText(errorCorrectionOptions[0], false);
+                dropdownMenuErrorCorrection.setAdapter(dropdownAdapterErrorCorrection);
+            }
+
+            //Update icon
+            ImageView barcodeFormatIcon = findViewById(R.id.iconImageView);
+            Glide.with(this).load(AppCompatResources.getDrawable(this, barcodeFormatIcons[Arrays.asList(barcodeFormats).indexOf(barcodeFormat.name())])).into(barcodeFormatIcon);
+        }
+
+        String errorCorrectionLevel = dropdownMenuErrorCorrection.getText().toString();
+        try {
+            Glide.with(this).load(QRGeneratorUtils.createImage(this, qrInputText, qrInputType, barcodeFormat, errorCorrectionLevel)).into(myImage);
+        } catch (IllegalArgumentException e) {
+            Toast.makeText(this, R.string.code_generation_error, Toast.LENGTH_SHORT).show();
+            Log.d(getClass().getSimpleName(), "Error during code generation.", e);
+        }
     }
 
     @Override

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/activities/generator/QrGeneratorDisplayActivity.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/activities/generator/QrGeneratorDisplayActivity.java
@@ -41,13 +41,13 @@ public class QrGeneratorDisplayActivity extends AppCompatActivity {
     String qrInputText = "";
     Contents.Type qrInputType = Contents.Type.UNDEFINED;
 
-    private final String[] barcodeFormats = new String[]{
+    private String[] barcodeFormats = new String[]{
             BarcodeFormat.QR_CODE.name(),
             BarcodeFormat.AZTEC.name(),
             BarcodeFormat.DATA_MATRIX.name(),
             BarcodeFormat.PDF_417.name(),
             BarcodeFormat.CODE_128.name()};
-    private final Integer[] barcodeFormatIcons = new Integer[]{
+    private Integer[] barcodeFormatIcons = new Integer[]{
             R.drawable.ic_baseline_qr_code_24dp,
             R.drawable.ic_aztec_code_24dp,
             R.drawable.ic_data_matrix_code_24dp,
@@ -73,6 +73,10 @@ public class QrGeneratorDisplayActivity extends AppCompatActivity {
         barcodeFormatMenu = findViewById(R.id.editBarcodeFormat);
         errorCorrectionMenu = findViewById(R.id.editErrorCorrection);
 
+        if (Build.VERSION.SDK_INT < 19) {
+            barcodeFormats = new String[]{BarcodeFormat.QR_CODE.name(), BarcodeFormat.CODE_128.name()};
+            barcodeFormatIcons = new Integer[]{R.drawable.ic_baseline_qr_code_24dp, R.drawable.ic_barcode_24dp};
+        }
 
         barcodeFormatMenu.setOnItemClickListener((parent, view, position, id) -> {
             updateDropDownMenus();

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/activities/generator/QrGeneratorDisplayActivity.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/activities/generator/QrGeneratorDisplayActivity.java
@@ -22,6 +22,7 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 
 import com.bumptech.glide.Glide;
+import com.bumptech.glide.request.target.BitmapImageViewTarget;
 import com.google.android.material.textfield.TextInputLayout;
 import com.google.zxing.BarcodeFormat;
 import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel;
@@ -159,7 +160,7 @@ public class QrGeneratorDisplayActivity extends AppCompatActivity {
         String errorCorrectionLevel = errorCorrectionMenu.getText().toString();
         try {
             Log.d(getClass().getSimpleName(), "Creating image...");
-            Glide.with(this).load(QRGeneratorUtils.createImage(this, qrInputText, qrInputType, barcodeFormat, errorCorrectionLevel)).into(myImage);
+            Glide.with(this).asBitmap().load(QRGeneratorUtils.createImage(this, qrInputText, qrInputType, barcodeFormat, errorCorrectionLevel)).into(new BitmapImageViewTarget(myImage));
         } catch (IllegalArgumentException e) {
             Toast.makeText(this, R.string.code_generation_error, Toast.LENGTH_SHORT).show();
             Log.d(getClass().getSimpleName(), "Error during code generation.", e);

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/activities/generator/QrGeneratorDisplayActivity.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/activities/generator/QrGeneratorDisplayActivity.java
@@ -59,7 +59,7 @@ public class QrGeneratorDisplayActivity extends AppCompatActivity {
 
     private final String[] errorCorrectionsQR = new String[]{ErrorCorrectionLevel.L.name(), ErrorCorrectionLevel.M.name(), ErrorCorrectionLevel.Q.name(), ErrorCorrectionLevel.H.name()};
     private final String[] errorCorrectionsAztec = new String[]{"25", "50", "75", "90"};
-    private final String[] errorCorrectionsPDF417 = new String[]{"0", "1", "2", "3", "4", "5", "6", "7", "8"};
+    private final String[] errorCorrectionsPDF417 = new String[]{"2", "3", "4", "5", "6", "7", "8"};
     private String[] currentErrorCorrections = errorCorrectionsQR;
     private ArrayAdapter<String> errorCorrectionAdapter;
     private AutoCompleteTextView errorCorrectionMenu;

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/helpers/IconArrayAdapter.kt
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/helpers/IconArrayAdapter.kt
@@ -1,0 +1,39 @@
+package com.secuso.privacyfriendlycodescanner.qrscanner.ui.helpers
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.ImageView
+import android.widget.TextView
+import com.secuso.privacyfriendlycodescanner.qrscanner.R
+
+/**
+ * ArrayAdapter with support for one icon and string for each item.
+ * @param layoutResource layout for the list item, must contain both R.id.textView and R.id.imageView
+ */
+class IconArrayAdapter(
+    context: Context,
+    private val layoutResource: Int,
+    private val strings: Array<String>,
+    private val icons: Array<Int>
+) : ArrayAdapter<String>(
+    context,
+    layoutResource,
+    strings
+) {
+
+    override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View {
+        return getView(position, convertView, parent)
+    }
+
+    override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+        val inflater: LayoutInflater = LayoutInflater.from(context)
+        val item: View =
+            convertView ?: inflater.inflate(layoutResource, parent, false)
+        item.findViewById<TextView>(R.id.textView)?.text = strings[position]
+        item.findViewById<ImageView>(R.id.imageView)?.setImageResource(icons[position])
+        return item
+    }
+}

--- a/app/src/main/res/layout-land/activity_qr_generator_display.xml
+++ b/app/src/main/res/layout-land/activity_qr_generator_display.xml
@@ -19,22 +19,16 @@
             android:id="@+id/scrollViewContent"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingBottom="80dp">
-
-            <androidx.constraintlayout.widget.Guideline
-                android:id="@+id/guidelineStart"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                app:layout_constraintGuide_begin="32dp" />
+            android:paddingBottom="0dp">
 
             <ImageView
                 android:id="@+id/iconImageView"
                 style="@style/AppTheme.Generator.Icon"
                 android:layout_width="40dp"
                 android:layout_height="40dp"
+                android:layout_marginStart="32dp"
                 android:layout_marginTop="12dp"
-                app:layout_constraintStart_toStartOf="@id/guidelineStart"
+                app:layout_constraintStart_toStartOf="@id/centerGuidline"
                 app:layout_constraintTop_toTopOf="@+id/editBarcodeFormatInputLayout"
                 app:srcCompat="@drawable/ic_baseline_qr_code_24dp"
                 tools:ignore="ContentDescription" />
@@ -46,9 +40,9 @@
                 android:layout_height="wrap_content"
                 android:layout_centerHorizontal="true"
                 android:layout_marginStart="16dp"
-                android:layout_marginTop="32dp"
-                android:layout_marginEnd="48dp"
-                app:layout_constraintEnd_toEndOf="@+id/resultQRCodeImage"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="32dp"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@id/iconImageView"
                 app:layout_constraintTop_toTopOf="parent">
 
@@ -68,8 +62,7 @@
                 android:layout_centerHorizontal="true"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="16dp"
-                android:layout_marginEnd="48dp"
-                app:layout_constraintEnd_toEndOf="@+id/resultQRCodeImage"
+                app:layout_constraintEnd_toEndOf="@+id/editBarcodeFormatInputLayout"
                 app:layout_constraintStart_toEndOf="@id/iconImageView"
                 app:layout_constraintTop_toBottomOf="@id/editBarcodeFormatInputLayout">
 
@@ -81,19 +74,33 @@
                     android:inputType="none" />
             </com.google.android.material.textfield.TextInputLayout>
 
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/centerGuidline"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintGuide_percent="0.5" />
+
             <ImageView
                 android:id="@+id/resultQRCodeImage"
                 android:layout_width="300dp"
                 android:layout_height="300dp"
-                android:layout_marginTop="48dp"
+                android:layout_marginTop="8dp"
                 android:background="@color/white"
                 android:padding="2dp"
-                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/centerGuidline"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/editErrorCorrectionInputLayout"
+                app:layout_constraintTop_toTopOf="parent"
                 app:srcCompat="@drawable/ic_no_image_accent_24dp" />
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline3"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent=".5" />
 
     <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
         android:id="@+id/btnStore"
@@ -109,5 +116,5 @@
         app:icon="@drawable/ic_baseline_save_alt_24dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="@+id/guideline3" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout-land/activity_qr_generator_display.xml
+++ b/app/src/main/res/layout-land/activity_qr_generator_display.xml
@@ -81,17 +81,28 @@
                 android:orientation="vertical"
                 app:layout_constraintGuide_percent="0.5" />
 
-            <ImageView
-                android:id="@+id/resultQRCodeImage"
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/resultImageContainer"
                 android:layout_width="300dp"
                 android:layout_height="300dp"
                 android:layout_marginTop="8dp"
-                android:background="@color/white"
-                android:padding="2dp"
                 app:layout_constraintEnd_toStartOf="@+id/centerGuidline"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:srcCompat="@drawable/ic_no_image_accent_24dp" />
+                app:layout_constraintTop_toTopOf="parent">
+
+                <ImageView
+                    android:id="@+id/resultQRCodeImage"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:adjustViewBounds="true"
+                    android:background="@color/white"
+                    android:padding="15dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:srcCompat="@drawable/ic_no_image_accent_24dp" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
 

--- a/app/src/main/res/layout/activity_qr_generator_display.xml
+++ b/app/src/main/res/layout/activity_qr_generator_display.xml
@@ -48,7 +48,7 @@
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="32dp"
                 android:layout_marginEnd="48dp"
-                app:layout_constraintEnd_toEndOf="@+id/resultQRCodeImage"
+                app:layout_constraintEnd_toEndOf="@+id/resultImageContainer"
                 app:layout_constraintStart_toEndOf="@id/iconImageView"
                 app:layout_constraintTop_toTopOf="parent">
 
@@ -69,7 +69,7 @@
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="16dp"
                 android:layout_marginEnd="48dp"
-                app:layout_constraintEnd_toEndOf="@+id/resultQRCodeImage"
+                app:layout_constraintEnd_toEndOf="@+id/resultImageContainer"
                 app:layout_constraintStart_toEndOf="@id/iconImageView"
                 app:layout_constraintTop_toBottomOf="@id/editBarcodeFormatInputLayout">
 
@@ -81,17 +81,28 @@
                     android:inputType="none" />
             </com.google.android.material.textfield.TextInputLayout>
 
-            <ImageView
-                android:id="@+id/resultQRCodeImage"
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/resultImageContainer"
                 android:layout_width="300dp"
                 android:layout_height="300dp"
                 android:layout_marginTop="48dp"
-                android:background="@color/white"
-                android:padding="2dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/editErrorCorrectionInputLayout"
-                app:srcCompat="@drawable/ic_no_image_accent_24dp" />
+                app:layout_constraintTop_toBottomOf="@+id/editErrorCorrectionInputLayout">
+
+                <ImageView
+                    android:id="@+id/resultQRCodeImage"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:adjustViewBounds="true"
+                    android:background="@color/white"
+                    android:padding="15dp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:srcCompat="@drawable/ic_no_image_accent_24dp" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
 

--- a/app/src/main/res/layout/activity_qr_generator_display.xml
+++ b/app/src/main/res/layout/activity_qr_generator_display.xml
@@ -2,18 +2,96 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/rootView"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <ImageView
-        android:id="@+id/resultQRCodeImage"
-        android:layout_width="300dp"
-        android:layout_height="300dp"
+    <ScrollView
+        android:id="@+id/scrollView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:srcCompat="@drawable/ic_no_image_accent_24dp" />
+        app:layout_constraintTop_toTopOf="parent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/scrollViewContent"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="80dp">
+
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/guidelineStart"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintGuide_begin="32dp" />
+
+            <ImageView
+                android:id="@+id/iconImageView"
+                style="@style/AppTheme.Generator.Icon"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:layout_marginTop="12dp"
+                app:layout_constraintStart_toStartOf="@id/guidelineStart"
+                app:layout_constraintTop_toTopOf="@+id/editBarcodeFormatInputLayout"
+                app:srcCompat="@drawable/ic_baseline_qr_code_24dp"
+                tools:ignore="ContentDescription" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/editBarcodeFormatInputLayout"
+                style="@style/AppTheme.Generator.ExposedDropdownMenu"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_centerHorizontal="true"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="32dp"
+                android:layout_marginEnd="48dp"
+                app:layout_constraintEnd_toEndOf="@+id/resultQRCodeImage"
+                app:layout_constraintStart_toEndOf="@id/iconImageView"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <AutoCompleteTextView
+                    android:id="@+id/editBarcodeFormat"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/barcode_format"
+                    android:inputType="none" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/editErrorCorrectionInputLayout"
+                style="@style/AppTheme.Generator.ExposedDropdownMenu"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_centerHorizontal="true"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="48dp"
+                app:layout_constraintEnd_toEndOf="@+id/resultQRCodeImage"
+                app:layout_constraintStart_toEndOf="@id/iconImageView"
+                app:layout_constraintTop_toBottomOf="@id/editBarcodeFormatInputLayout">
+
+                <AutoCompleteTextView
+                    android:id="@+id/editErrorCorrection"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/error_correction_level"
+                    android:inputType="none" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <ImageView
+                android:id="@+id/resultQRCodeImage"
+                android:layout_width="300dp"
+                android:layout_height="300dp"
+                android:layout_marginTop="48dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/editErrorCorrectionInputLayout"
+                app:srcCompat="@drawable/ic_no_image_accent_24dp" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
 
     <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
         android:id="@+id/btnStore"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -324,5 +324,8 @@
     <string name="image_is_being_processed">Bild wird verarbeitet…</string>
     <string name="no_code_in_image_explanation">Leider konnte in diesem Bild kein Code gefunden werden. Um das Ergebnis zu verbessern, können Sie das Bild zuschneiden oder begradigen und es erneut versuchen.</string>
     <string name="select_image_from_gallery_explanation">Mit dieser Funktion können Sie Bilder aus Ihrer Galerie öffnen und darin enthaltene Codes scannen. Dazu ist der Zugriff auf die Bilder erforderlich.</string>
+    <string name="error_correction_level">Fehlerkorrektur-Level</string>
+    <string name="barcode_format">Format</string>
+    <string name="code_generation_error">Es konnte kein Code generiert werden.</string>
 
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -335,6 +335,9 @@
     <string name="image_is_being_processed">L\'immagine è in fase di elaborazione…</string>
     <string name="no_code_in_image_explanation">Purtroppo non è stato possibile trovare alcun codice in questa immagine. Per migliorare il risultato, è possibile ritagliare o raddrizzare l\'immagine e riprovare.</string>
     <string name="select_image_from_gallery_explanation">Questa funzione consente di aprire le immagini della propria galleria e di scansionare i codici in esse contenuti. Ciò richiede l\'accesso alle immagini.</string>
+    <string name="error_correction_level">Livello di correzione degli errori</string>
+    <string name="barcode_format">Formato</string>
+    <string name="code_generation_error">Non è stato possibile generare alcun codice.</string>
 
 
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -331,5 +331,8 @@
     <string name="image_is_being_processed">Beeld wordt verwerkt…</string>
     <string name="no_code_in_image_explanation">Helaas kon in dit beeld geen code worden gevonden. Om het resultaat te verbeteren, kunt u de afbeelding bijsnijden of rechtzetten en het opnieuw proberen.</string>
     <string name="select_image_from_gallery_explanation">Met deze functie kunt u afbeeldingen uit uw galerij openen en de codes in de afbeeldingen scannen. Hiervoor is toegang tot de afbeeldingen nodig.</string>
+    <string name="error_correction_level">Foutcorrectieniveau</string>
+    <string name="barcode_format">Formaat</string>
+    <string name="code_generation_error">Er kon geen code worden gegenereerd.</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -248,6 +248,9 @@
     <string name="text_enter">The text you want to encode</string>
     <string name="hello_world">Hello World</string>
     <string name="generate">generate</string>
+    <string name="barcode_format">Format</string>
+    <string name="error_correction_level">Error correction level</string>
+    <string name="code_generation_error">No code could be generated.</string>
 
     <string name="generator_text_textfield">Text</string>
     <string name="generator_text_explanation">You can enter any text you want to encode. Multiple lines are allowed.</string>


### PR DESCRIPTION
Add option to generate different code formats with different error correction levels.
This adds AZTEC, DATA MATRIX, PDF 417 and CODE 128 since these seem to work on most data.
On API < 19 only QR-Code and CODE 128 are supported.

Closes #131 