### PR TITLE
Fix #142: Dialogs in dark theme

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,9 +50,9 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.4.2'
+    implementation 'androidx.appcompat:appcompat:1.5.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'com.google.android.material:material:1.2.1'
+    implementation 'com.google.android.material:material:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.cardview:cardview:1.0.0'
     testImplementation 'junit:junit:4.13.2'

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/activities/HistoryActivity.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/activities/HistoryActivity.java
@@ -7,13 +7,13 @@ import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
 
-import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.secuso.privacyfriendlycodescanner.qrscanner.R;
 import com.secuso.privacyfriendlycodescanner.qrscanner.database.AppRepository;
 import com.secuso.privacyfriendlycodescanner.qrscanner.ui.adapter.HistoryAdapter;
@@ -64,7 +64,8 @@ public class HistoryActivity extends AppCompatActivity {
                     icon.setTint(getResources().getColor(R.color.red));
                 }
             }
-            new AlertDialog.Builder(this)
+
+            new MaterialAlertDialogBuilder(this)
                     .setTitle(R.string.D_all)
                     .setMessage(R.string.all_records)
                     .setPositiveButton(R.string.delete, new DialogInterface.OnClickListener() {

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/activities/ScannerActivity.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/activities/ScannerActivity.java
@@ -24,6 +24,7 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.lifecycle.ViewModelProvider;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.navigation.NavigationView;
 import com.google.zxing.BarcodeFormat;
 import com.google.zxing.ResultPoint;
@@ -149,13 +150,13 @@ public class ScannerActivity extends BaseActivity implements NavigationView.OnNa
                 BarcodeResult result = viewModel.getScanResult().getValue();
                 viewModel.clearScanResult();
                 if (result == null) {
-                    AlertDialog.Builder builder = new AlertDialog.Builder(this);
-                    builder.setMessage(R.string.no_code_in_image_explanation)
+                    new MaterialAlertDialogBuilder(this)
+                            .setMessage(R.string.no_code_in_image_explanation)
                             .setTitle(R.string.app_name)
                             .setIcon(R.drawable.ic_baseline_qr_code_24dp)
                             .setCancelable(true)
-                            .setPositiveButton(R.string.okay, null);
-                    builder.create().show();
+                            .setPositiveButton(R.string.okay, null)
+                            .show();
                 } else {
                     onBarcodeResult(result);
                 }
@@ -327,10 +328,17 @@ public class ScannerActivity extends BaseActivity implements NavigationView.OnNa
 
     private void onOpenImagePickerClick() {
         if (PreferenceManager.getDefaultSharedPreferences(getBaseContext()).getBoolean("image_picker_first_click", true)) {
-            new AlertDialog.Builder(ScannerActivity.this).setMessage(R.string.select_image_from_gallery_explanation).setPositiveButton(R.string.proceed, (dialogInterface, i) -> {
-                openImagePicker();
-                PreferenceManager.getDefaultSharedPreferences(getBaseContext()).edit().putBoolean("image_picker_first_click", Boolean.FALSE).apply();
-            }).setTitle(R.string.select_image_from_gallery).setCancelable(true).create().show();
+            new MaterialAlertDialogBuilder(ScannerActivity.this)
+                    .setMessage(R.string.select_image_from_gallery_explanation)
+                    .setPositiveButton(R.string.proceed, (dialogInterface, i) ->
+                    {
+                        openImagePicker();
+                        PreferenceManager.getDefaultSharedPreferences(getBaseContext()).edit().putBoolean("image_picker_first_click", Boolean.FALSE).apply();
+                    })
+                    .setTitle(R.string.select_image_from_gallery)
+                    .setCancelable(true)
+                    .create()
+                    .show();
         } else {
             openImagePicker();
         }

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/dialogfragments/QRCodeImageDialogFragment.kt
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/dialogfragments/QRCodeImageDialogFragment.kt
@@ -23,7 +23,7 @@ class QRCodeImageDialogFragment : DialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         return activity?.let {
-            val builder = MaterialAlertDialogBuilder(context!!, R.style.AppTheme_CustomMaterialDialog)
+            val builder = MaterialAlertDialogBuilder(context!!)
             val dialogView = it.layoutInflater.inflate(R.layout.dialog_image_view, null)
             val imageView = dialogView.findViewById<ImageView>(R.id.imageView)
             val progressBar = dialogView.findViewById<ProgressBar>(R.id.progressBar)

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/dialogfragments/RawDataDialogFragment.kt
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/dialogfragments/RawDataDialogFragment.kt
@@ -15,7 +15,7 @@ class RawDataDialogFragment : DialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         return activity?.let {
-            val builder = MaterialAlertDialogBuilder(context!!, R.style.AppTheme_CustomMaterialDialog)
+            val builder = MaterialAlertDialogBuilder(context!!)
             val rawData: String = arguments!!.getString("rawDataString") ?: ""
             val dialogView = activity!!.layoutInflater.inflate(R.layout.dialog_raw_data, null)
             val textView = dialogView.findViewById<TextView>(R.id.textView)

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/resultfragments/ContactResultFragment.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/resultfragments/ContactResultFragment.java
@@ -10,10 +10,10 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.zxing.client.result.AddressBookParsedResult;
 import com.secuso.privacyfriendlycodescanner.qrscanner.R;
 import com.secuso.privacyfriendlycodescanner.qrscanner.ui.adapter.ContactResultAdapter;
@@ -54,8 +54,8 @@ public class ContactResultFragment extends ResultFragment {
     //TODO: Add missing: multiple names, all nicknames, pronunciation, instant messenger, birthday, geo
     //See: zxing/core/src/main/java/com/google/zxing/client/result/AddressBookParsedResult.java
     public void onProceedPressed(Context context) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(context);
-        builder.setTitle(R.string.choose_action)
+        new MaterialAlertDialogBuilder(context)
+                .setTitle(R.string.choose_action)
                 .setItems(R.array.vcard_array, (dialog, which) -> {
                     switch (which) {
                         case 0:
@@ -89,7 +89,7 @@ public class ContactResultFragment extends ResultFragment {
 
                         default:
                     }
-                });
-        builder.create().show();
+                })
+                .show();
     }
 }

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/resultfragments/EmailResultFragment.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/resultfragments/EmailResultFragment.java
@@ -10,10 +10,10 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.zxing.client.result.EmailAddressParsedResult;
 import com.secuso.privacyfriendlycodescanner.qrscanner.R;
 import com.secuso.privacyfriendlycodescanner.qrscanner.ui.adapter.EmailResultAdapter;
@@ -46,8 +46,8 @@ public class EmailResultFragment extends ResultFragment {
     @Override
     public void onProceedPressed(Context context) {
         // TODO: rework this..
-        AlertDialog.Builder builder = new AlertDialog.Builder(context);
-        builder.setTitle(R.string.choose_action)
+        new MaterialAlertDialogBuilder(context)
+                .setTitle(R.string.choose_action)
                 .setItems(R.array.send_email_array, (dialog, which) -> {
                     String caption = "";
                     switch (which) {
@@ -57,7 +57,7 @@ public class EmailResultFragment extends ResultFragment {
                             email.putExtra(Intent.EXTRA_EMAIL, result.getTos());
                             email.putExtra(Intent.EXTRA_SUBJECT, result.getSubject());
                             email.putExtra(Intent.EXTRA_TEXT, result.getBody());
-                            caption =getResources().getStringArray(R.array.send_email_array)[0];
+                            caption = getResources().getStringArray(R.array.send_email_array)[0];
                             startActivity(Intent.createChooser(email, caption));
                             break;
                         case 1:
@@ -68,8 +68,8 @@ public class EmailResultFragment extends ResultFragment {
                             break;
                         default:
                     }
-                });
-        builder.create().show();
+                })
+                .show();
     }
 
 

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/resultfragments/GeoResultFragment.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/resultfragments/GeoResultFragment.java
@@ -11,8 +11,7 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import androidx.appcompat.app.AlertDialog;
-
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.zxing.client.result.GeoParsedResult;
 import com.secuso.privacyfriendlycodescanner.qrscanner.R;
 
@@ -59,8 +58,8 @@ public class GeoResultFragment extends ResultFragment {
     }
 
     public void onProceedPressed(Context context) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(context);
-        builder.setTitle(R.string.choose_action)
+        new MaterialAlertDialogBuilder(context)
+                .setTitle(R.string.choose_action)
                 .setItems(R.array.geo_array, (dialog, which) -> {
                     String caption = "";
                     switch (which) {
@@ -70,13 +69,10 @@ public class GeoResultFragment extends ResultFragment {
                             mapIntent.setData(gmmIntentUri);
 
                             startActivity(Intent.createChooser(mapIntent, caption));
-
-
                             break;
-
                         default:
                     }
-                });
-        builder.create().show();
+                })
+                .show();
     }
 }

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/resultfragments/SMSResultFragment.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/resultfragments/SMSResultFragment.java
@@ -12,8 +12,8 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.zxing.client.result.ParsedResult;
 import com.google.zxing.client.result.SMSParsedResult;
 import com.secuso.privacyfriendlycodescanner.qrscanner.R;
@@ -41,7 +41,7 @@ public class SMSResultFragment extends ResultFragment {
         TextView subjectLabel = (TextView) v.findViewById(R.id.fragment_result_sms_subject_label);
         TextView body = (TextView) v.findViewById(R.id.fragment_result_sms_body);
 
-        if(result != null) {
+        if (result != null) {
             StringBuilder numberSb = new StringBuilder();
             ParsedResult.maybeAppend(result.getNumbers(), numberSb);
 
@@ -66,14 +66,14 @@ public class SMSResultFragment extends ResultFragment {
     }
 
     public void onProceedPressed(Context context) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(context);
-        builder.setTitle(R.string.choose_action)
+        new MaterialAlertDialogBuilder(context)
+                .setTitle(R.string.choose_action)
                 .setItems(R.array.sms_array, (dialog, which) -> {
                     String caption = "";
                     switch (which) {
                         case 0:
                             Intent sms = new Intent(Intent.ACTION_SENDTO, Uri.parse("smsto:" + result.getNumbers()[0]));
-                            sms.putExtra("address",  result.getNumbers()[0]);
+                            sms.putExtra("address", result.getNumbers()[0]);
                             sms.putExtra("sms_body", result.getBody());
                             caption = getResources().getStringArray(R.array.sms_array)[0];
                             startActivity(Intent.createChooser(sms, caption));
@@ -93,7 +93,7 @@ public class SMSResultFragment extends ResultFragment {
                             break;
                         default:
                     }
-                });
-        builder.create().show();
+                })
+                .show();
     }
 }

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/resultfragments/TelResultFragment.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/resultfragments/TelResultFragment.java
@@ -10,8 +10,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
-import androidx.appcompat.app.AlertDialog;
-
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.zxing.client.result.TelParsedResult;
 import com.secuso.privacyfriendlycodescanner.qrscanner.R;
 
@@ -38,8 +37,8 @@ public class TelResultFragment extends ResultFragment {
     }
 
     public void onProceedPressed(final Context context) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(context);
-        builder.setTitle(R.string.choose_action)
+        new MaterialAlertDialogBuilder(context)
+                .setTitle(R.string.choose_action)
                 .setItems(R.array.tel_array, (dialog, which) -> {
                     switch (which) {
                         case 0:
@@ -52,7 +51,7 @@ public class TelResultFragment extends ResultFragment {
                             break;
                         default:
                     }
-                });
-        builder.create().show();
+                })
+                .show();
     }
 }

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/resultfragments/WifiResultFragment.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/resultfragments/WifiResultFragment.java
@@ -8,8 +8,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
-import androidx.appcompat.app.AlertDialog;
-
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.zxing.client.result.WifiParsedResult;
 import com.secuso.privacyfriendlycodescanner.qrscanner.R;
 
@@ -46,8 +45,8 @@ public class WifiResultFragment extends ResultFragment {
     }
 
     public void onProceedPressed(final Context context) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(context);
-        builder.setTitle(R.string.choose_action)
+        new MaterialAlertDialogBuilder(context)
+                .setTitle(R.string.choose_action)
                 .setItems(R.array.wifi_array, (dialog, which) -> {
                     switch (which) {
                         case 0:
@@ -57,7 +56,7 @@ public class WifiResultFragment extends ResultFragment {
 
                         default:
                     }
-                });
-        builder.create().show();
+                })
+                .show();
     }
 }

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/viewmodel/HistoryItemViewModel.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/viewmodel/HistoryItemViewModel.java
@@ -4,9 +4,9 @@ import android.content.Context;
 import android.text.format.DateUtils;
 import android.view.View;
 
-import androidx.appcompat.app.AlertDialog;
 import androidx.databinding.BaseObservable;
 
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.zxing.client.result.ParsedResult;
 import com.google.zxing.client.result.ResultParser;
 import com.secuso.privacyfriendlycodescanner.qrscanner.R;
@@ -49,15 +49,15 @@ public class HistoryItemViewModel extends BaseObservable {
     public View.OnLongClickListener onLongClickItem() {
         return v -> {
             if (!isDisabled()) {
-                AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(context);
-                dialogBuilder.setTitle(R.string.dialog_history_delete_title);
-                dialogBuilder.setMessage(R.string.dialog_history_delete_message);
-                dialogBuilder.setPositiveButton(R.string.delete, (dialog, which) -> {
-                    disabled = true;
-                    AppRepository.getInstance(context).deleteHistoryEntry(entry);
-                });
-                dialogBuilder.setNegativeButton(android.R.string.cancel, null);
-                dialogBuilder.create().show();
+                new MaterialAlertDialogBuilder(context)
+                        .setTitle(R.string.dialog_history_delete_title)
+                        .setMessage(R.string.dialog_history_delete_message)
+                        .setPositiveButton(R.string.delete, (dialog, which) -> {
+                            disabled = true;
+                            AppRepository.getInstance(context).deleteHistoryEntry(entry);
+                        })
+                        .setNegativeButton(android.R.string.cancel, null)
+                        .show();
                 return true;
             }
             return false;

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/util/WebSearchUtil.kt
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/util/WebSearchUtil.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.preference.PreferenceManager
-import androidx.appcompat.app.AlertDialog
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.secuso.privacyfriendlycodescanner.qrscanner.R
 
 object WebSearchUtil {
@@ -12,7 +12,7 @@ object WebSearchUtil {
     @JvmStatic
     fun openWebSearchDialog(context: Context, content: String) {
         val searchEngineURI = getSearchEngineURI(context)
-        val dialog: AlertDialog = AlertDialog.Builder(context)
+        MaterialAlertDialogBuilder(context)
             .setMessage(
                 context.resources.getString(
                     R.string.fragment_result_text_dialog_message,
@@ -31,8 +31,8 @@ object WebSearchUtil {
                     context.resources.getStringArray(R.array.text_array).get(0)
                 context.startActivity(Intent.createChooser(search, caption))
             }
-            .setNegativeButton(android.R.string.cancel, null).create()
-        dialog.show()
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
     }
 
     private fun getPrefSearchEngineIndex(context: Context): Int {

--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -12,11 +12,11 @@
         <item name="colorHistoryIconBackground">@color/middledarkgrey</item>
         <item name="colorHistoryIcons">?attr/colorIcons</item>
         <item name="colorHighlight">@color/highlight_transparent_light</item>
-        <item name="colorSelectableItemHighlight">@color/highlight_selectable_transparent_light
-        </item>
+        <item name="colorSelectableItemHighlight">@color/highlight_selectable_transparent_light</item>
         <item name="colorNavbarHeaderBackground">@color/darkgrey</item>
         <item name="colorNavbarHeaderText">@color/colorAccent</item>
         <item name="colorURLHighlight">@color/white</item>
+        <item name="materialAlertDialogTheme">@style/AppTheme.CustomMaterialDialog</item>
     </style>
 
     <style name="AppTheme.CustomMaterialDialog" parent="@style/ThemeOverlay.MaterialComponents.MaterialAlertDialog">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -13,12 +13,14 @@
         <item name="colorHistoryIconBackground">@color/white</item>
         <item name="colorHistoryIcons">?attr/colorIcons</item>
         <item name="colorHighlight">@color/highlight_transparent_light</item>
-        <item name="colorSelectableItemHighlight">@color/highlight_selectable_transparent_dark
-        </item>
+        <item name="colorSelectableItemHighlight">@color/highlight_selectable_transparent_dark</item>
         <item name="colorNavbarHeaderBackground">@color/white</item>
         <item name="colorNavbarHeaderText">@color/colorPrimary</item>
         <item name="colorURLHighlight">@color/black</item>
+        <item name="materialAlertDialogTheme">@style/AppTheme.CustomMaterialDialog</item>
     </style>
+
+    <style name="AppTheme.CustomMaterialDialog" parent="@style/ThemeOverlay.MaterialComponents.MaterialAlertDialog" />
 
     <style name="AppTheme.NoActionBar">
         <item name="windowActionBar">false</item>


### PR DESCRIPTION
This PR fixes issue #142 by adjusting the theme to use a different color in dialogs.
The new colors are auto-applied because I also migrated all `AlertDialog.Builder` occurrences to `MaterialAlertDialogBuilder`.
Also the necessary dependencies were updated.

_All changes are based on this information: [material.io](https://material.io/components/dialogs/android#theming-dialogs)_

![grafik](https://user-images.githubusercontent.com/6222752/188122338-6876f37c-9851-4ed6-ab52-1d01a9e3ecf1.png)