### PR TITLE
Add monochrome icon variant for android 13

### DIFF
--- a/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -1,0 +1,103 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="512"
+    android:viewportHeight="512">
+  <group>
+    <clip-path android:pathData="M0,0h512v512h-512z M 0,0"/>
+    <path
+        android:pathData="M68.577,449.74h169.261V280.479H68.577V449.74zM219.031,430.934H87.384V299.287h131.647V430.934z"
+        android:fillColor="#FFFFFF"/>
+  </group>
+  <group>
+    <clip-path android:pathData="M0,0h512v512h-512z M 0,0"/>
+    <path
+        android:pathData="M106.191,318.094h94.033v94.033h-94.033z"
+        android:fillColor="#FFFFFF"/>
+  </group>
+  <group>
+    <clip-path android:pathData="M0,0h512v512h-512z M 0,0"/>
+    <path
+        android:pathData="M68.577,242.866h169.261V73.605H68.577V242.866zM219.031,224.06H87.384V92.413h131.647V224.06z"
+        android:fillColor="#FFFFFF"/>
+  </group>
+  <group>
+    <clip-path android:pathData="M0,0h512v512h-512z M 0,0"/>
+    <path
+        android:pathData="M106.191,111.219h94.033v94.034h-94.033z"
+        android:fillColor="#FFFFFF"/>
+  </group>
+  <group>
+    <clip-path android:pathData="M0,0h512v512h-512z M 0,0"/>
+    <path
+        android:pathData="M275.451,449.74h169.261V280.479H275.451V449.74zM425.905,430.934H294.258V299.287h131.647V430.934z"
+        android:fillColor="#FFFFFF"/>
+  </group>
+  <group>
+    <clip-path android:pathData="M0,0h512v512h-512z M 0,0"/>
+    <path
+        android:pathData="M313.065,318.094h94.033v94.033h-94.033z"
+        android:fillColor="#FFFFFF"/>
+  </group>
+  <group>
+    <clip-path android:pathData="M0,0h512v512h-512z M 0,0"/>
+    <path
+        android:pathData="M275.451,205.252h37.613v37.614h-37.613z"
+        android:fillColor="#FFFFFF"/>
+  </group>
+  <group>
+    <clip-path android:pathData="M0,0h512v512h-512z M 0,0"/>
+    <path
+        android:pathData="M275.451,167.639h18.807v18.807h-18.807z"
+        android:fillColor="#FFFFFF"/>
+  </group>
+  <group>
+    <clip-path android:pathData="M0,0h512v512h-512z M 0,0"/>
+    <path
+        android:pathData="M294.258,148.832h37.613v18.807h-37.613z"
+        android:fillColor="#FFFFFF"/>
+  </group>
+  <group>
+    <clip-path android:pathData="M0,0h512v512h-512z M 0,0"/>
+    <path
+        android:pathData="M331.871,92.412l0,-18.807l-18.807,0l-18.806,0l-18.807,0l0,18.807l18.807,0l0,37.614l18.806,0l18.807,0l0,-18.807l-18.807,0l0,-18.807z"
+        android:fillColor="#FFFFFF"/>
+  </group>
+  <group>
+    <clip-path android:pathData="M0,0h512v512h-512z M 0,0"/>
+    <path
+        android:pathData="M369.484,224.059h75.228v18.807h-75.228z"
+        android:fillColor="#FFFFFF"/>
+  </group>
+  <group>
+    <clip-path android:pathData="M0,0h512v512h-512z M 0,0"/>
+    <path
+        android:pathData="M369.484,186.446l0,-18.807l-18.805,0l0,18.807l-18.808,0l0,56.42l18.808,0l0,-37.613l37.613,0l0,-18.807z"
+        android:fillColor="#FFFFFF"/>
+  </group>
+  <group>
+    <clip-path android:pathData="M0,0h512v512h-512z M 0,0"/>
+    <path
+        android:pathData="M275.451,130.026h18.807v18.807h-18.807z"
+        android:fillColor="#FFFFFF"/>
+  </group>
+  <group>
+    <clip-path android:pathData="M0,0h512v512h-512z M 0,0"/>
+    <path
+        android:pathData="M425.905,148.833l-18.807,0l0,18.807l-18.806,0l0,18.805l18.806,0l18.807,0l0,18.807l18.807,0l0,-56.419z"
+        android:fillColor="#FFFFFF"/>
+  </group>
+  <group>
+    <clip-path android:pathData="M0,0h512v512h-512z M 0,0"/>
+    <path
+        android:pathData="M425.905,73.605l-18.807,0l0,18.808l18.807,0l0,37.612l18.807,0l0,-56.42z"
+        android:fillColor="#FFFFFF"/>
+  </group>
+  <group>
+    <clip-path android:pathData="M0,0h512v512h-512z M 0,0"/>
+    <path
+        android:pathData="M388.292,92.412V73.605h-18.808v18.807h-18.806v37.614h-18.808v18.807h18.808h56.419V92.412H388.292zM388.292,130.026h-18.808v-18.807h18.808V130.026z"
+        android:fillColor="#FFFFFF"/>
+  </group>
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -3,7 +3,10 @@
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground>
         <inset android:drawable="@drawable/ic_launcher_foreground"
-            android:inset="20%"/>
+            android:inset="22%"/>
     </foreground>
-    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
+    <monochrome>
+        <inset android:drawable="@drawable/ic_launcher_monochrome"
+            android:inset="22%"/>
+    </monochrome>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -5,4 +5,5 @@
         <inset android:drawable="@drawable/ic_launcher_foreground"
             android:inset="20%"/>
     </foreground>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
 </adaptive-icon>


### PR DESCRIPTION
Hi!

I recently upgraded to android 13 and noticed that your app does not yet support monochrome app icons for theming. This makes the app stand out quite a bit when placed next to other apps that do support theming, so I added a simple monochrome version of the app icon.

[privacy]

Here's a before and after showing the themed and un-themed icon next to some other themed apps:
![unthemed](https://github.com/SecUSo/privacy-friendly-qr-scanner/assets/6852884/fa4a360c-3cb0-4ee3-88c1-6d95cfa8a2c0)
![themed](https://github.com/SecUSo/privacy-friendly-qr-scanner/assets/6852884/3e0317fc-045c-4bc3-bdee-0f26de00875b)
