### PR TITLE
Fix NPE in some cases

### DIFF
--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/activities/generator/QrGeneratorDisplayActivity.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/activities/generator/QrGeneratorDisplayActivity.java
@@ -267,8 +267,6 @@ public class QrGeneratorDisplayActivity extends AppCompatActivity {
         barcodeFormatAdapter = newBarcodeFormatAdapter();
         barcodeFormatMenu.setAdapter(barcodeFormatAdapter);
 
-        errorCorrectionAdapter = newErrorCorrectionAdapter(currentErrorCorrections);
-        errorCorrectionMenu.setAdapter(errorCorrectionAdapter);
         updateDropDownMenus();
         generateAndUpdateImage();
     }


### PR DESCRIPTION
`currentErrorCorrections` might be null in some cases (see #177). The same functionality is already called in `updateDropDownMenus#updateErrorCorrectionMenu` with the necessary null check in place. So these lines are not needed.

Fixes #177