### PR TITLE
declare android:installLocation to auto

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    android:installLocation="auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.CAMERA" />


### PR DESCRIPTION
Allows the app to be installed/moved to the external storage (e.g. SD card), as per the [docs](https://developer.android.com/guide/topics/data/install-location).

This is useful for users like me who's running out of internal storage space.

Thanks.