### PR TITLE
#98 Show scanned payment codes (EPC/GiroCode, bank://, EMV/Pix) in a structured view

### DIFF
--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/payment/Crc16.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/payment/Crc16.java
@@ -1,0 +1,73 @@
+/*
+    Privacy Friendly QR Scanner
+    Copyright (C) 2025 Privacy Friendly QR Scanner authors and SECUSO
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package com.secuso.privacyfriendlycodescanner.qrscanner.payment;
+
+import java.io.UnsupportedEncodingException;
+
+/**
+ * CRC-16/CCITT-FALSE implementation as required by the EMVCo Merchant Presented Mode
+ * QR specification (polynomial 0x1021, initial value 0xFFFF, no reflection, no final XOR).
+ * <p>
+ * Pure Java with no Android dependencies so it can be exercised with JVM unit tests.
+ */
+public final class Crc16 {
+
+    private static final int POLYNOMIAL = 0x1021;
+    private static final int INITIAL_VALUE = 0xFFFF;
+
+    private Crc16() {
+    }
+
+    /**
+     * Computes the CRC-16/CCITT-FALSE over the ASCII bytes of the given string.
+     *
+     * @return the CRC as an unsigned 16-bit value
+     */
+    public static int compute(String data) {
+        int crc = INITIAL_VALUE;
+        // EMV / Pix payloads are encoded as UTF-8; compute the CRC over those bytes.
+        byte[] bytes;
+        try {
+            bytes = data.getBytes("UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            // UTF-8 is guaranteed to be available on every platform.
+            bytes = data.getBytes();
+        }
+        for (byte b : bytes) {
+            crc ^= (b & 0xFF) << 8;
+            for (int i = 0; i < 8; i++) {
+                if ((crc & 0x8000) != 0) {
+                    crc = (crc << 1) ^ POLYNOMIAL;
+                } else {
+                    crc <<= 1;
+                }
+                crc &= 0xFFFF;
+            }
+        }
+        return crc & 0xFFFF;
+    }
+
+    /**
+     * Returns the CRC as an upper case, zero-padded four digit hex string, matching the
+     * representation used inside EMV / Pix payloads.
+     */
+    public static String computeHex(String data) {
+        return String.format("%04X", compute(data));
+    }
+}

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/payment/Crc16.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/payment/Crc16.java
@@ -35,7 +35,7 @@ public final class Crc16 {
     }
 
     /**
-     * Computes the CRC-16/CCITT-FALSE over the ASCII bytes of the given string.
+     * Computes the CRC-16/CCITT-FALSE over the UTF-8 bytes of the given string.
      *
      * @return the CRC as an unsigned 16-bit value
      */

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/payment/Iban.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/payment/Iban.java
@@ -1,0 +1,81 @@
+/*
+    Privacy Friendly QR Scanner
+    Copyright (C) 2025 Privacy Friendly QR Scanner authors and SECUSO
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package com.secuso.privacyfriendlycodescanner.qrscanner.payment;
+
+import java.math.BigInteger;
+
+/**
+ * Validation helper for International Bank Account Numbers (IBAN) following the
+ * ISO 13616 structure and the ISO 7064 MOD 97-10 check.
+ * <p>
+ * Pure Java with no Android dependencies so it can be exercised with JVM unit tests.
+ */
+public final class Iban {
+
+    private static final BigInteger NINETY_SEVEN = BigInteger.valueOf(97);
+
+    private Iban() {
+    }
+
+    /**
+     * Removes spaces and converts to upper case, leaving the IBAN otherwise untouched.
+     */
+    public static String normalize(String iban) {
+        if (iban == null) {
+            return null;
+        }
+        return iban.replace(" ", "").trim().toUpperCase();
+    }
+
+    /**
+     * Checks whether the given string is a structurally valid IBAN that passes the MOD 97-10 check.
+     *
+     * @param input the candidate IBAN (spaces are tolerated)
+     * @return {@code true} if the input is a valid IBAN
+     */
+    public static boolean isValid(String input) {
+        String iban = normalize(input);
+        if (iban == null || iban.length() < 15 || iban.length() > 34) {
+            return false;
+        }
+        // Two letters (country), two digits (check), then alphanumeric.
+        if (!iban.matches("[A-Z]{2}[0-9]{2}[A-Z0-9]+")) {
+            return false;
+        }
+        // Move the four initial characters to the end of the string.
+        String rearranged = iban.substring(4) + iban.substring(0, 4);
+        // Replace each letter with two digits: A = 10, B = 11, ..., Z = 35.
+        StringBuilder numeric = new StringBuilder(rearranged.length() * 2);
+        for (int i = 0; i < rearranged.length(); i++) {
+            char c = rearranged.charAt(i);
+            if (c >= '0' && c <= '9') {
+                numeric.append(c);
+            } else if (c >= 'A' && c <= 'Z') {
+                numeric.append(c - 'A' + 10);
+            } else {
+                return false;
+            }
+        }
+        try {
+            return new BigInteger(numeric.toString()).mod(NINETY_SEVEN).intValue() == 1;
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+}

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/payment/Iban.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/payment/Iban.java
@@ -19,6 +19,7 @@
 package com.secuso.privacyfriendlycodescanner.qrscanner.payment;
 
 import java.math.BigInteger;
+import java.util.Locale;
 
 /**
  * Validation helper for International Bank Account Numbers (IBAN) following the
@@ -40,7 +41,7 @@ public final class Iban {
         if (iban == null) {
             return null;
         }
-        return iban.replace(" ", "").trim().toUpperCase();
+        return iban.replace(" ", "").trim().toUpperCase(Locale.ROOT);
     }
 
     /**

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/payment/PaymentCode.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/payment/PaymentCode.java
@@ -1,0 +1,252 @@
+/*
+    Privacy Friendly QR Scanner
+    Copyright (C) 2025 Privacy Friendly QR Scanner authors and SECUSO
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package com.secuso.privacyfriendlycodescanner.qrscanner.payment;
+
+/**
+ * Immutable, Android-independent representation of a parsed payment QR code.
+ * <p>
+ * The union of fields across all supported formats is held here; fields that are
+ * not present in a given format (or were optional and omitted) stay {@code null}.
+ * The UI hides empty fields. Instances are produced by {@link PaymentCodeParser}.
+ */
+public final class PaymentCode {
+
+    public enum Type {
+        /** European Payments Council Quick Response Code (a.k.a. GiroCode). */
+        EPC,
+        /** {@code bank://singlepaymentsepa?...} URL variant. */
+        BANK_URL,
+        /** EMVCo Merchant Presented Mode code, including the Brazilian Pix scheme. */
+        EMV
+    }
+
+    private final Type type;
+    private final boolean pixScheme;
+
+    private final String version;
+    private final String recipientName;
+    private final String iban;
+    private final String bic;
+    private final String amount;
+    private final String currency;
+    private final String remittance;
+    private final String purposeCode;
+    private final String reference;
+    private final String city;
+    private final String countryCode;
+    private final String pixKey;
+    private final String pixInfo;
+
+    private PaymentCode(Builder b) {
+        this.type = b.type;
+        this.pixScheme = b.pixScheme;
+        this.version = b.version;
+        this.recipientName = b.recipientName;
+        this.iban = b.iban;
+        this.bic = b.bic;
+        this.amount = b.amount;
+        this.currency = b.currency;
+        this.remittance = b.remittance;
+        this.purposeCode = b.purposeCode;
+        this.reference = b.reference;
+        this.city = b.city;
+        this.countryCode = b.countryCode;
+        this.pixKey = b.pixKey;
+        this.pixInfo = b.pixInfo;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    /** {@code true} only for {@link Type#EMV} codes that declare the {@code br.gov.bcb.pix} GUI. */
+    public boolean isPixScheme() {
+        return pixScheme;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getRecipientName() {
+        return recipientName;
+    }
+
+    public String getIban() {
+        return iban;
+    }
+
+    public String getBic() {
+        return bic;
+    }
+
+    public String getAmount() {
+        return amount;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public String getRemittance() {
+        return remittance;
+    }
+
+    public String getPurposeCode() {
+        return purposeCode;
+    }
+
+    public String getReference() {
+        return reference;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public String getCountryCode() {
+        return countryCode;
+    }
+
+    public String getPixKey() {
+        return pixKey;
+    }
+
+    public String getPixInfo() {
+        return pixInfo;
+    }
+
+    /**
+     * Convenience: combines amount and currency for display, e.g. {@code "12.50 EUR"}.
+     * Returns {@code null} if no amount is present.
+     */
+    public String getFormattedAmount() {
+        if (amount == null || amount.isEmpty()) {
+            return null;
+        }
+        if (currency == null || currency.isEmpty()) {
+            return amount;
+        }
+        return amount + " " + currency;
+    }
+
+    static final class Builder {
+        private final Type type;
+        private boolean pixScheme;
+        private String version;
+        private String recipientName;
+        private String iban;
+        private String bic;
+        private String amount;
+        private String currency;
+        private String remittance;
+        private String purposeCode;
+        private String reference;
+        private String city;
+        private String countryCode;
+        private String pixKey;
+        private String pixInfo;
+
+        Builder(Type type) {
+            this.type = type;
+        }
+
+        Builder pixScheme(boolean v) {
+            this.pixScheme = v;
+            return this;
+        }
+
+        Builder version(String v) {
+            this.version = emptyToNull(v);
+            return this;
+        }
+
+        Builder recipientName(String v) {
+            this.recipientName = emptyToNull(v);
+            return this;
+        }
+
+        Builder iban(String v) {
+            this.iban = emptyToNull(v);
+            return this;
+        }
+
+        Builder bic(String v) {
+            this.bic = emptyToNull(v);
+            return this;
+        }
+
+        Builder amount(String v) {
+            this.amount = emptyToNull(v);
+            return this;
+        }
+
+        Builder currency(String v) {
+            this.currency = emptyToNull(v);
+            return this;
+        }
+
+        Builder remittance(String v) {
+            this.remittance = emptyToNull(v);
+            return this;
+        }
+
+        Builder purposeCode(String v) {
+            this.purposeCode = emptyToNull(v);
+            return this;
+        }
+
+        Builder reference(String v) {
+            this.reference = emptyToNull(v);
+            return this;
+        }
+
+        Builder city(String v) {
+            this.city = emptyToNull(v);
+            return this;
+        }
+
+        Builder countryCode(String v) {
+            this.countryCode = emptyToNull(v);
+            return this;
+        }
+
+        Builder pixKey(String v) {
+            this.pixKey = emptyToNull(v);
+            return this;
+        }
+
+        Builder pixInfo(String v) {
+            this.pixInfo = emptyToNull(v);
+            return this;
+        }
+
+        PaymentCode build() {
+            return new PaymentCode(this);
+        }
+
+        private static String emptyToNull(String v) {
+            if (v == null) {
+                return null;
+            }
+            String trimmed = v.trim();
+            return trimmed.isEmpty() ? null : trimmed;
+        }
+    }
+}

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/payment/PaymentCodeParser.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/payment/PaymentCodeParser.java
@@ -1,0 +1,333 @@
+/*
+    Privacy Friendly QR Scanner
+    Copyright (C) 2025 Privacy Friendly QR Scanner authors and SECUSO
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package com.secuso.privacyfriendlycodescanner.qrscanner.payment;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Detects and parses payment QR codes into a {@link PaymentCode}.
+ * <p>
+ * Detection is <b>strict</b>: a code is only recognised when its signature matches and
+ * all mandatory fields are present and valid (IBAN MOD 97-10 for EPC / bank URLs,
+ * CRC-16 for EMV). Anything else yields {@code null}, leaving the caller to fall back
+ * to the unchanged default handling. Parsing is exception safe and never throws.
+ * <p>
+ * Currency is treated purely as informational data and is never used as an acceptance
+ * criterion, so non-euro EMV codes (e.g. Pix in BRL) are supported.
+ * <p>
+ * Pure Java with no Android dependencies so it can be exercised with JVM unit tests.
+ */
+public final class PaymentCodeParser {
+
+    private static final String BANK_URL_PREFIX = "bank://singlepaymentsepa";
+
+    /** ISO 4217 numeric to alphabetic mapping for the most common currencies. */
+    private static final Map<String, String> CURRENCY_CODES = new HashMap<>();
+
+    static {
+        CURRENCY_CODES.put("986", "BRL");
+        CURRENCY_CODES.put("978", "EUR");
+        CURRENCY_CODES.put("840", "USD");
+        CURRENCY_CODES.put("826", "GBP");
+        CURRENCY_CODES.put("756", "CHF");
+        CURRENCY_CODES.put("392", "JPY");
+        CURRENCY_CODES.put("156", "CNY");
+        CURRENCY_CODES.put("036", "AUD");
+        CURRENCY_CODES.put("124", "CAD");
+        CURRENCY_CODES.put("752", "SEK");
+        CURRENCY_CODES.put("578", "NOK");
+        CURRENCY_CODES.put("208", "DKK");
+        CURRENCY_CODES.put("985", "PLN");
+    }
+
+    private PaymentCodeParser() {
+    }
+
+    /**
+     * Attempts to parse the raw decoded QR content as a payment code.
+     *
+     * @param raw the raw text of the scanned code
+     * @return a {@link PaymentCode} or {@code null} if the content is not a recognised,
+     * fully valid payment code
+     */
+    public static PaymentCode parse(String raw) {
+        if (raw == null) {
+            return null;
+        }
+        try {
+            String trimmed = raw.trim();
+            if (trimmed.isEmpty()) {
+                return null;
+            }
+            String lower = trimmed.toLowerCase();
+            if (trimmed.startsWith("BCD\n") || trimmed.startsWith("BCD\r\n")) {
+                return parseEpc(trimmed);
+            }
+            if (lower.startsWith(BANK_URL_PREFIX)) {
+                return parseBankUrl(trimmed);
+            }
+            if (trimmed.startsWith("000201") || trimmed.startsWith("000202")) {
+                return parseEmv(trimmed);
+            }
+            return null;
+        } catch (RuntimeException e) {
+            // Strict parsing: any unexpected condition means "not a payment code".
+            return null;
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // EPC / GiroCode
+    // ------------------------------------------------------------------
+
+    private static PaymentCode parseEpc(String raw) {
+        // EPC uses LF separators; tolerate CRLF by stripping the CR.
+        String[] lines = raw.replace("\r\n", "\n").split("\n", -1);
+        // Mandatory elements run up to and including the IBAN (index 6).
+        if (lines.length < 7) {
+            return null;
+        }
+        String serviceTag = lines[0].trim();
+        String version = lines[1].trim();
+        String charset = lines[2].trim();
+        String identification = lines[3].trim();
+        String bic = lines[4].trim();
+        String name = lines[5].trim();
+        String iban = lines[6].trim();
+
+        if (!"BCD".equals(serviceTag)) {
+            return null;
+        }
+        if (!"001".equals(version) && !"002".equals(version)) {
+            return null;
+        }
+        if (!charset.matches("[1-8]")) {
+            return null;
+        }
+        if (!"SCT".equals(identification)) {
+            return null;
+        }
+        if (name.isEmpty()) {
+            return null;
+        }
+        if (!Iban.isValid(iban)) {
+            return null;
+        }
+        // BIC is mandatory in version 001 and optional in version 002.
+        if ("001".equals(version) && bic.isEmpty()) {
+            return null;
+        }
+
+        PaymentCode.Builder builder = new PaymentCode.Builder(PaymentCode.Type.EPC)
+                .version(version)
+                .bic(bic)
+                .recipientName(name)
+                .iban(Iban.normalize(iban));
+
+        // Amount (optional), formatted as a three letter currency followed by the value.
+        if (lines.length > 7) {
+            String amountField = lines[7].trim();
+            if (!amountField.isEmpty()) {
+                if (!amountField.matches("[A-Z]{3}\\d+(\\.\\d+)?")) {
+                    return null; // present but malformed -> strict reject
+                }
+                builder.currency(amountField.substring(0, 3));
+                builder.amount(amountField.substring(3));
+            }
+        }
+        if (lines.length > 8) {
+            builder.purposeCode(lines[8].trim());
+        }
+        // Either a structured reference (index 9) or unstructured remittance text (index 10).
+        if (lines.length > 9) {
+            builder.reference(lines[9].trim());
+        }
+        if (lines.length > 10) {
+            builder.remittance(lines[10].trim());
+        }
+        return builder.build();
+    }
+
+    // ------------------------------------------------------------------
+    // bank://singlepaymentsepa?...
+    // ------------------------------------------------------------------
+
+    private static PaymentCode parseBankUrl(String raw) {
+        int queryStart = raw.indexOf('?');
+        if (queryStart < 0 || queryStart == raw.length() - 1) {
+            return null;
+        }
+        Map<String, String> params = new HashMap<>();
+        for (String pair : raw.substring(queryStart + 1).split("&")) {
+            int eq = pair.indexOf('=');
+            if (eq <= 0) {
+                continue;
+            }
+            String key = decode(pair.substring(0, eq)).toLowerCase();
+            String value = decode(pair.substring(eq + 1));
+            params.put(key, value);
+        }
+
+        String name = params.get("name");
+        String iban = params.get("iban");
+        if (name == null || name.trim().isEmpty()) {
+            return null;
+        }
+        if (!Iban.isValid(iban)) {
+            return null;
+        }
+
+        return new PaymentCode.Builder(PaymentCode.Type.BANK_URL)
+                .recipientName(name)
+                .iban(Iban.normalize(iban))
+                .bic(params.get("bic"))
+                .amount(params.get("amount"))
+                .currency(params.get("currency"))
+                .remittance(params.get("reason"))
+                .build();
+    }
+
+    private static String decode(String s) {
+        try {
+            return URLDecoder.decode(s, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            return s;
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // EMVCo Merchant Presented Mode (incl. Pix)
+    // ------------------------------------------------------------------
+
+    private static PaymentCode parseEmv(String raw) {
+        // The CRC tag "63" with length "04" must be present; validate it strictly.
+        int crcTag = raw.lastIndexOf("6304");
+        if (crcTag < 0 || crcTag + 8 != raw.length()) {
+            return null;
+        }
+        String provided = raw.substring(crcTag + 4);
+        String computed = Crc16.computeHex(raw.substring(0, crcTag + 4));
+        if (!provided.equalsIgnoreCase(computed)) {
+            return null;
+        }
+
+        Map<String, String> root = parseTlv(raw);
+        if (root == null || !root.containsKey("00")) {
+            return null;
+        }
+
+        String name = root.get("59");
+        if (name == null || name.trim().isEmpty()) {
+            return null;
+        }
+
+        // Locate a merchant account information template (tags 02..51) and read the scheme.
+        boolean pixScheme = false;
+        String pixKey = null;
+        String pixInfo = null;
+        for (int tag = 2; tag <= 51; tag++) {
+            String key = String.format("%02d", tag);
+            String template = root.get(key);
+            if (template == null) {
+                continue;
+            }
+            Map<String, String> account = parseTlv(template);
+            if (account == null) {
+                continue;
+            }
+            String gui = account.get("00");
+            if (gui != null && gui.toLowerCase().contains("br.gov.bcb.pix")) {
+                pixScheme = true;
+                if (pixKey == null) {
+                    pixKey = account.get("01");
+                }
+                if (pixInfo == null) {
+                    pixInfo = account.get("02");
+                }
+            } else if (pixKey == null) {
+                // Generic EMV: keep the first identifier we encounter as a fallback.
+                pixKey = account.get("01");
+            }
+        }
+
+        String reference = null;
+        String additional = root.get("62");
+        if (additional != null) {
+            Map<String, String> additionalData = parseTlv(additional);
+            if (additionalData != null) {
+                reference = additionalData.get("05");
+            }
+        }
+
+        return new PaymentCode.Builder(PaymentCode.Type.EMV)
+                .pixScheme(pixScheme)
+                .recipientName(name)
+                .city(root.get("60"))
+                .amount(root.get("54"))
+                .currency(resolveCurrency(root.get("53")))
+                .countryCode(root.get("58"))
+                .pixKey(pixKey)
+                .pixInfo(pixInfo)
+                .reference(reference)
+                .build();
+    }
+
+    /**
+     * Parses a flat EMV TLV string into a tag to value map. Returns {@code null} when the
+     * structure is malformed (e.g. a declared length exceeds the remaining input).
+     */
+    private static Map<String, String> parseTlv(String data) {
+        Map<String, String> result = new HashMap<>();
+        int i = 0;
+        int n = data.length();
+        while (i + 4 <= n) {
+            String tag = data.substring(i, i + 2);
+            if (!tag.matches("\\d{2}")) {
+                return null;
+            }
+            String lengthStr = data.substring(i + 2, i + 4);
+            if (!lengthStr.matches("\\d{2}")) {
+                return null;
+            }
+            int length = Integer.parseInt(lengthStr);
+            int valueStart = i + 4;
+            int valueEnd = valueStart + length;
+            if (valueEnd > n) {
+                return null;
+            }
+            result.put(tag, data.substring(valueStart, valueEnd));
+            i = valueEnd;
+        }
+        if (i != n) {
+            return null; // trailing bytes that do not form a complete TLV
+        }
+        return result;
+    }
+
+    private static String resolveCurrency(String numeric) {
+        if (numeric == null) {
+            return null;
+        }
+        String code = CURRENCY_CODES.get(numeric.trim());
+        return code != null ? code : numeric.trim();
+    }
+}

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/payment/PaymentCodeParser.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/payment/PaymentCodeParser.java
@@ -21,6 +21,7 @@ package com.secuso.privacyfriendlycodescanner.qrscanner.payment;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -38,7 +39,7 @@ import java.util.Map;
  */
 public final class PaymentCodeParser {
 
-    private static final String BANK_URL_PREFIX = "bank://singlepaymentsepa";
+    private static final String BANK_URL_PREFIX = "bank://singlepaymentsepa?";
 
     /** ISO 4217 numeric to alphabetic mapping for the most common currencies. */
     private static final Map<String, String> CURRENCY_CODES = new HashMap<>();
@@ -78,7 +79,7 @@ public final class PaymentCodeParser {
             if (trimmed.isEmpty()) {
                 return null;
             }
-            String lower = trimmed.toLowerCase();
+            String lower = trimmed.toLowerCase(Locale.ROOT);
             if (trimmed.startsWith("BCD\n") || trimmed.startsWith("BCD\r\n")) {
                 return parseEpc(trimmed);
             }
@@ -182,7 +183,7 @@ public final class PaymentCodeParser {
             if (eq <= 0) {
                 continue;
             }
-            String key = decode(pair.substring(0, eq)).toLowerCase();
+            String key = decode(pair.substring(0, eq)).toLowerCase(Locale.ROOT);
             String value = decode(pair.substring(eq + 1));
             params.put(key, value);
         }
@@ -255,7 +256,7 @@ public final class PaymentCodeParser {
                 continue;
             }
             String gui = account.get("00");
-            if (gui != null && gui.toLowerCase().contains("br.gov.bcb.pix")) {
+            if ("br.gov.bcb.pix".equalsIgnoreCase(gui)) {
                 pixScheme = true;
                 if (pixKey == null) {
                     pixKey = account.get("01");

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/activities/ResultActivity.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/activities/ResultActivity.java
@@ -47,12 +47,16 @@ import com.secuso.privacyfriendlycodescanner.qrscanner.R;
 import com.secuso.privacyfriendlycodescanner.qrscanner.database.HistoryItem;
 import com.secuso.privacyfriendlycodescanner.qrscanner.generator.Contents;
 import com.secuso.privacyfriendlycodescanner.qrscanner.helpers.Utils;
+import com.secuso.privacyfriendlycodescanner.qrscanner.payment.PaymentCode;
 import com.secuso.privacyfriendlycodescanner.qrscanner.ui.dialogfragments.QRCodeImageDialogFragment;
 import com.secuso.privacyfriendlycodescanner.qrscanner.ui.dialogfragments.RawDataDialogFragment;
+import com.secuso.privacyfriendlycodescanner.qrscanner.ui.resultfragments.BankUrlResultFragment;
 import com.secuso.privacyfriendlycodescanner.qrscanner.ui.resultfragments.CalendarResultFragment;
 import com.secuso.privacyfriendlycodescanner.qrscanner.ui.resultfragments.ContactResultFragment;
 import com.secuso.privacyfriendlycodescanner.qrscanner.ui.resultfragments.EmailResultFragment;
+import com.secuso.privacyfriendlycodescanner.qrscanner.ui.resultfragments.EpcResultFragment;
 import com.secuso.privacyfriendlycodescanner.qrscanner.ui.resultfragments.GeoResultFragment;
+import com.secuso.privacyfriendlycodescanner.qrscanner.ui.resultfragments.PixResultFragment;
 import com.secuso.privacyfriendlycodescanner.qrscanner.ui.resultfragments.ProductResultFragment;
 import com.secuso.privacyfriendlycodescanner.qrscanner.ui.resultfragments.ResultFragment;
 import com.secuso.privacyfriendlycodescanner.qrscanner.ui.resultfragments.SMSResultFragment;
@@ -203,7 +207,11 @@ public class ResultActivity extends AppCompatActivity {
         codeTypeText.setText(viewModel.currentHistoryItem.getFormat().toString());
 
         Glide.with(this).load(viewModel.mCodeImage).into(qrImageView);
-        qrTypeText.setText(Contents.Type.parseParsedResultType(viewModel.mParsedResult.getType()).toLocalizedString(getApplicationContext()));
+        if (viewModel.mPaymentCode != null) {
+            qrTypeText.setText(paymentTypeLabel(viewModel.mPaymentCode));
+        } else {
+            qrTypeText.setText(Contents.Type.parseParsedResultType(viewModel.mParsedResult.getType()).toLocalizedString(getApplicationContext()));
+        }
 
         long timestamp = viewModel.currentHistoryItem.getTimestamp();
         if (timestamp != 0) {
@@ -263,6 +271,13 @@ public class ResultActivity extends AppCompatActivity {
             return;
         }
 
+        // Payment codes (EPC/GiroCode, bank:// URL, EMV/Pix) are not recognised by ZXing's
+        // ParsedResultType, so route them to a dedicated fragment before the default dispatch.
+        // If no payment code was detected, the original handling below stays unchanged.
+        if (viewModel.mPaymentCode != null && loadPaymentFragment(parsedResult)) {
+            return;
+        }
+
         FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
 
         ResultFragment resultFragment;
@@ -318,5 +333,53 @@ public class ResultActivity extends AppCompatActivity {
         ft.commit();
 
         chooseActionButton.setText(resultFragment.getProceedButtonTitle(this));
+    }
+
+    /**
+     * Loads the result fragment matching the detected {@link PaymentCode}.
+     *
+     * @return {@code true} if a payment fragment was loaded, {@code false} otherwise
+     */
+    private boolean loadPaymentFragment(ParsedResult parsedResult) {
+        ResultFragment resultFragment;
+        switch (viewModel.mPaymentCode.getType()) {
+            case EPC:
+                resultFragment = new EpcResultFragment();
+                break;
+            case BANK_URL:
+                resultFragment = new BankUrlResultFragment();
+                break;
+            case EMV:
+                resultFragment = new PixResultFragment();
+                break;
+            default:
+                return false;
+        }
+
+        currentResultFragment = resultFragment;
+        resultFragment.putQRCode(parsedResult);
+
+        FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
+        ft.replace(R.id.activity_result_frame_layout, resultFragment);
+        ft.commit();
+
+        chooseActionButton.setText(resultFragment.getProceedButtonTitle(this));
+        return true;
+    }
+
+    /**
+     * Returns the localized type label for the detected payment code, used as the heading.
+     */
+    private String paymentTypeLabel(@NonNull PaymentCode paymentCode) {
+        switch (paymentCode.getType()) {
+            case EPC:
+                return getString(R.string.payment_type_epc);
+            case BANK_URL:
+                return getString(R.string.payment_type_bank_url);
+            case EMV:
+                return getString(paymentCode.isPixScheme() ? R.string.payment_type_pix : R.string.payment_type_emv);
+            default:
+                return null;
+        }
     }
 }

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/resultfragments/BankUrlResultFragment.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/resultfragments/BankUrlResultFragment.java
@@ -1,0 +1,77 @@
+/*
+    Privacy Friendly QR Scanner
+    Copyright (C) 2025 Privacy Friendly QR Scanner authors and SECUSO
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package com.secuso.privacyfriendlycodescanner.qrscanner.ui.resultfragments;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+
+import com.secuso.privacyfriendlycodescanner.qrscanner.R;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Displays a scanned {@code bank://singlepaymentsepa} payment URL in a structured form.
+ */
+public class BankUrlResultFragment extends PaymentResultFragment {
+
+    public BankUrlResultFragment() {
+        // Required empty public constructor
+    }
+
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        super.onCreateView(inflater, container, savedInstanceState);
+        View v = inflater.inflate(R.layout.fragment_result_payment_bank_url, container, false);
+        if (payment == null) {
+            return v;
+        }
+
+        bindField(v, R.id.result_field_bank_name, R.string.payment_recipient_value, payment.getRecipientName());
+        bindField(v, R.id.result_field_bank_iban, R.string.payment_iban_value, payment.getIban());
+        bindField(v, R.id.result_field_bank_bic, R.string.payment_bic_value, payment.getBic());
+        bindField(v, R.id.result_field_bank_amount, R.string.payment_amount_value, payment.getFormattedAmount());
+        bindField(v, R.id.result_field_bank_remittance, R.string.payment_purpose_value, payment.getRemittance());
+
+        return v;
+    }
+
+    @Override
+    public void onProceedPressed(Context context) {
+        if (payment == null) {
+            return;
+        }
+        List<CopyItem> items = new ArrayList<>();
+        addCopyItem(items, R.string.payment_copy_iban, payment.getIban());
+        addCopyItem(items, R.string.payment_copy_amount, payment.getAmount());
+        addCopyItem(items, R.string.payment_copy_purpose, payment.getRemittance());
+        addCopyItem(items, R.string.payment_copy_recipient, payment.getRecipientName());
+        showCopyDialog(context, items);
+    }
+
+    @Override
+    public String getProceedButtonTitle(Context context) {
+        return context.getString(R.string.payment_copy_field);
+    }
+}

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/resultfragments/EpcResultFragment.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/resultfragments/EpcResultFragment.java
@@ -1,0 +1,87 @@
+/*
+    Privacy Friendly QR Scanner
+    Copyright (C) 2025 Privacy Friendly QR Scanner authors and SECUSO
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package com.secuso.privacyfriendlycodescanner.qrscanner.ui.resultfragments;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+
+import com.secuso.privacyfriendlycodescanner.qrscanner.R;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Displays a scanned EPC / GiroCode (SEPA Credit Transfer) in a structured form.
+ */
+public class EpcResultFragment extends PaymentResultFragment {
+
+    public EpcResultFragment() {
+        // Required empty public constructor
+    }
+
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        super.onCreateView(inflater, container, savedInstanceState);
+        View v = inflater.inflate(R.layout.fragment_result_payment_epc, container, false);
+        if (payment == null) {
+            return v;
+        }
+
+        bindField(v, R.id.result_field_epc_name, R.string.payment_recipient_value, payment.getRecipientName());
+        bindField(v, R.id.result_field_epc_iban, R.string.payment_iban_value, payment.getIban());
+        bindField(v, R.id.result_field_epc_bic, R.string.payment_bic_value, payment.getBic());
+        bindField(v, R.id.result_field_epc_amount, R.string.payment_amount_value, payment.getFormattedAmount());
+        bindField(v, R.id.result_field_epc_remittance, R.string.payment_purpose_value, remittance());
+        bindField(v, R.id.result_field_epc_purpose_code, R.string.payment_purpose_code_value, payment.getPurposeCode());
+        bindField(v, R.id.result_field_epc_version, R.string.payment_version_value, payment.getVersion());
+
+        return v;
+    }
+
+    /** Prefers the unstructured remittance text, falling back to the structured reference. */
+    private String remittance() {
+        if (payment.getRemittance() != null) {
+            return payment.getRemittance();
+        }
+        return payment.getReference();
+    }
+
+    @Override
+    public void onProceedPressed(Context context) {
+        if (payment == null) {
+            return;
+        }
+        List<CopyItem> items = new ArrayList<>();
+        addCopyItem(items, R.string.payment_copy_iban, payment.getIban());
+        addCopyItem(items, R.string.payment_copy_amount, payment.getAmount());
+        addCopyItem(items, R.string.payment_copy_purpose, remittance());
+        addCopyItem(items, R.string.payment_copy_recipient, payment.getRecipientName());
+        showCopyDialog(context, items);
+    }
+
+    @Override
+    public String getProceedButtonTitle(Context context) {
+        return context.getString(R.string.payment_copy_field);
+    }
+}

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/resultfragments/PaymentResultFragment.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/resultfragments/PaymentResultFragment.java
@@ -1,0 +1,121 @@
+/*
+    Privacy Friendly QR Scanner
+    Copyright (C) 2025 Privacy Friendly QR Scanner authors and SECUSO
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package com.secuso.privacyfriendlycodescanner.qrscanner.ui.resultfragments;
+
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.Context;
+import android.view.View;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.secuso.privacyfriendlycodescanner.qrscanner.R;
+import com.secuso.privacyfriendlycodescanner.qrscanner.payment.PaymentCode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Shared base for the payment code result fragments (EPC, bank URL, EMV/Pix).
+ * <p>
+ * Holds the parsed {@link PaymentCode} taken from the shared {@code ResultViewModel} and
+ * provides helpers to bind labelled fields and to offer a "copy single field" dialog,
+ * which is the proceed action chosen for all payment codes.
+ */
+public abstract class PaymentResultFragment extends ResultFragment {
+
+    protected PaymentCode payment;
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+        if (viewModel != null) {
+            payment = viewModel.mPaymentCode;
+        }
+    }
+
+    /**
+     * Sets {@code "label: value"} on the given text view, or hides it when the value is empty.
+     *
+     * @param labelRes a string resource with a single {@code %1$s} placeholder
+     */
+    protected void bindField(View root, int textViewId, @StringRes int labelRes, String value) {
+        TextView tv = root.findViewById(textViewId);
+        if (value == null || value.trim().isEmpty()) {
+            tv.setVisibility(View.GONE);
+        } else {
+            tv.setVisibility(View.VISIBLE);
+            tv.setText(getString(labelRes, value));
+        }
+    }
+
+    /**
+     * A single entry in the copy dialog: a human readable label and the value to copy.
+     */
+    protected static final class CopyItem {
+        final String label;
+        final String value;
+
+        CopyItem(String label, String value) {
+            this.label = label;
+            this.value = value;
+        }
+    }
+
+    /**
+     * Adds a copy entry only when the value is present.
+     */
+    protected void addCopyItem(List<CopyItem> items, @StringRes int labelRes, String value) {
+        if (value != null && !value.trim().isEmpty()) {
+            items.add(new CopyItem(getString(labelRes), value));
+        }
+    }
+
+    /**
+     * Shows a dialog letting the user copy one of the given fields (plus "copy everything").
+     */
+    protected void showCopyDialog(final Context context, List<CopyItem> items) {
+        final List<CopyItem> all = new ArrayList<>(items);
+        // Always offer to copy the full raw content.
+        all.add(new CopyItem(getString(R.string.payment_copy_all),
+                viewModel.currentHistoryItem.getText()));
+
+        String[] labels = new String[all.size()];
+        for (int i = 0; i < all.size(); i++) {
+            labels[i] = all.get(i).label;
+        }
+
+        new MaterialAlertDialogBuilder(context)
+                .setTitle(R.string.choose_action)
+                .setItems(labels, (dialog, which) -> copyToClipboard(context, all.get(which).value))
+                .show();
+    }
+
+    private void copyToClipboard(Context context, String value) {
+        ClipboardManager clipboard = (ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
+        if (clipboard != null) {
+            clipboard.setPrimaryClip(ClipData.newPlainText("Text", value));
+            android.widget.Toast.makeText(context, R.string.copied_to_clipboard,
+                    android.widget.Toast.LENGTH_SHORT).show();
+        }
+    }
+}

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/resultfragments/PixResultFragment.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/resultfragments/PixResultFragment.java
@@ -1,0 +1,79 @@
+/*
+    Privacy Friendly QR Scanner
+    Copyright (C) 2025 Privacy Friendly QR Scanner authors and SECUSO
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package com.secuso.privacyfriendlycodescanner.qrscanner.ui.resultfragments;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+
+import com.secuso.privacyfriendlycodescanner.qrscanner.R;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Displays a scanned EMVCo Merchant Presented Mode code (including Brazilian Pix) in a
+ * structured form.
+ */
+public class PixResultFragment extends PaymentResultFragment {
+
+    public PixResultFragment() {
+        // Required empty public constructor
+    }
+
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        super.onCreateView(inflater, container, savedInstanceState);
+        View v = inflater.inflate(R.layout.fragment_result_payment_pix, container, false);
+        if (payment == null) {
+            return v;
+        }
+
+        bindField(v, R.id.result_field_pix_name, R.string.payment_recipient_value, payment.getRecipientName());
+        bindField(v, R.id.result_field_pix_city, R.string.payment_city_value, payment.getCity());
+        bindField(v, R.id.result_field_pix_amount, R.string.payment_amount_value, payment.getFormattedAmount());
+        bindField(v, R.id.result_field_pix_key, R.string.payment_pix_key_value, payment.getPixKey());
+        bindField(v, R.id.result_field_pix_info, R.string.payment_pix_info_value, payment.getPixInfo());
+        bindField(v, R.id.result_field_pix_reference, R.string.payment_reference_value, payment.getReference());
+        bindField(v, R.id.result_field_pix_country, R.string.payment_country_value, payment.getCountryCode());
+
+        return v;
+    }
+
+    @Override
+    public void onProceedPressed(Context context) {
+        if (payment == null) {
+            return;
+        }
+        List<CopyItem> items = new ArrayList<>();
+        addCopyItem(items, R.string.payment_copy_pix_key, payment.getPixKey());
+        addCopyItem(items, R.string.payment_copy_amount, payment.getAmount());
+        addCopyItem(items, R.string.payment_copy_recipient, payment.getRecipientName());
+        showCopyDialog(context, items);
+    }
+
+    @Override
+    public String getProceedButtonTitle(Context context) {
+        return context.getString(R.string.payment_copy_field);
+    }
+}

--- a/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/viewmodel/ResultViewModel.java
+++ b/app/src/main/java/com/secuso/privacyfriendlycodescanner/qrscanner/ui/viewmodel/ResultViewModel.java
@@ -39,6 +39,8 @@ import com.secuso.privacyfriendlycodescanner.qrscanner.R;
 import com.secuso.privacyfriendlycodescanner.qrscanner.database.AppRepository;
 import com.secuso.privacyfriendlycodescanner.qrscanner.database.HistoryItem;
 import com.secuso.privacyfriendlycodescanner.qrscanner.helpers.Utils;
+import com.secuso.privacyfriendlycodescanner.qrscanner.payment.PaymentCode;
+import com.secuso.privacyfriendlycodescanner.qrscanner.payment.PaymentCodeParser;
 
 public class ResultViewModel extends AndroidViewModel {
 
@@ -48,6 +50,8 @@ public class ResultViewModel extends AndroidViewModel {
     public ParsedResult mParsedResult = null;
     public Bitmap mCodeImage = null;
     public boolean mSavedToHistory = false;
+    /** Non-null when the scanned content was recognised as a supported payment code. */
+    public PaymentCode mPaymentCode = null;
 
     private final SharedPreferences mPreferences;
 
@@ -71,6 +75,7 @@ public class ResultViewModel extends AndroidViewModel {
     public void initFromHistoryItem(HistoryItem historyItem) {
         currentHistoryItem = historyItem;
         mParsedResult = ResultParser.parseResult(currentHistoryItem.getResult());
+        mPaymentCode = PaymentCodeParser.parse(currentHistoryItem.getText());
         mCodeImage = currentHistoryItem.getImage();
         if (mCodeImage == null) {
             mCodeImage = Utils.generateCode(currentHistoryItem.getText(), BarcodeFormat.QR_CODE, null);
@@ -84,6 +89,7 @@ public class ResultViewModel extends AndroidViewModel {
     public void initFromScan(BarcodeResult barcodeResult) {
         currentBarcodeResult = barcodeResult;
         mParsedResult = ResultParser.parseResult(currentBarcodeResult.getResult());
+        mPaymentCode = PaymentCodeParser.parse(currentBarcodeResult.getText());
         fillMissingResultPoints();
         try {
             mCodeImage = currentBarcodeResult.getBitmapWithResultPoints(ContextCompat.getColor(getApplication(), R.color.colorAccent));

--- a/app/src/main/res/layout/fragment_result_payment_bank_url.xml
+++ b/app/src/main/res/layout/fragment_result_payment_bank_url.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:orientation="vertical">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <TextView
+                android:id="@+id/result_field_bank_explanation"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/payment_explanation_bank_url"
+                android:textSize="15sp" />
+
+            <TextView
+                android:id="@+id/result_field_bank_name"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:textIsSelectable="true"
+                android:textSize="18sp" />
+
+            <TextView
+                android:id="@+id/result_field_bank_iban"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textIsSelectable="true"
+                android:textSize="18sp" />
+
+            <TextView
+                android:id="@+id/result_field_bank_bic"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textIsSelectable="true"
+                android:textSize="18sp" />
+
+            <TextView
+                android:id="@+id/result_field_bank_amount"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textIsSelectable="true"
+                android:textSize="18sp" />
+
+            <TextView
+                android:id="@+id/result_field_bank_remittance"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textIsSelectable="true"
+                android:textSize="18sp" />
+
+        </LinearLayout>
+    </ScrollView>
+
+</RelativeLayout>

--- a/app/src/main/res/layout/fragment_result_payment_epc.xml
+++ b/app/src/main/res/layout/fragment_result_payment_epc.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:orientation="vertical">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <TextView
+                android:id="@+id/result_field_epc_explanation"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/payment_explanation_epc"
+                android:textSize="15sp" />
+
+            <TextView
+                android:id="@+id/result_field_epc_name"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:textIsSelectable="true"
+                android:textSize="18sp" />
+
+            <TextView
+                android:id="@+id/result_field_epc_iban"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textIsSelectable="true"
+                android:textSize="18sp" />
+
+            <TextView
+                android:id="@+id/result_field_epc_bic"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textIsSelectable="true"
+                android:textSize="18sp" />
+
+            <TextView
+                android:id="@+id/result_field_epc_amount"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textIsSelectable="true"
+                android:textSize="18sp" />
+
+            <TextView
+                android:id="@+id/result_field_epc_remittance"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textIsSelectable="true"
+                android:textSize="18sp" />
+
+            <TextView
+                android:id="@+id/result_field_epc_purpose_code"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textIsSelectable="true"
+                android:textSize="18sp" />
+
+            <TextView
+                android:id="@+id/result_field_epc_version"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textIsSelectable="true"
+                android:textSize="14sp" />
+
+        </LinearLayout>
+    </ScrollView>
+
+</RelativeLayout>

--- a/app/src/main/res/layout/fragment_result_payment_pix.xml
+++ b/app/src/main/res/layout/fragment_result_payment_pix.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:orientation="vertical">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <TextView
+                android:id="@+id/result_field_pix_explanation"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/payment_explanation_pix"
+                android:textSize="15sp" />
+
+            <TextView
+                android:id="@+id/result_field_pix_name"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:textIsSelectable="true"
+                android:textSize="18sp" />
+
+            <TextView
+                android:id="@+id/result_field_pix_city"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textIsSelectable="true"
+                android:textSize="18sp" />
+
+            <TextView
+                android:id="@+id/result_field_pix_amount"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textIsSelectable="true"
+                android:textSize="18sp" />
+
+            <TextView
+                android:id="@+id/result_field_pix_key"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textIsSelectable="true"
+                android:textSize="18sp" />
+
+            <TextView
+                android:id="@+id/result_field_pix_info"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textIsSelectable="true"
+                android:textSize="18sp" />
+
+            <TextView
+                android:id="@+id/result_field_pix_reference"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textIsSelectable="true"
+                android:textSize="18sp" />
+
+            <TextView
+                android:id="@+id/result_field_pix_country"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textIsSelectable="true"
+                android:textSize="14sp" />
+
+        </LinearLayout>
+    </ScrollView>
+
+</RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -381,4 +381,32 @@
     <string name="pref_custom_search_engine_title">Custom Search Engine</string>
     <string name="pref_custom_search_engine_summary">The URL to use as \"Custom Search Engine\". The search string will be inserted at %s.</string>
     <string name="pref_custom_search_engine_default" translatable="false">https://duckduckgo.com/?q=%s</string>
+
+    <!-- Payment codes (EPC/GiroCode, bank:// URL, EMV/Pix) -->
+    <string name="payment_type_epc">SEPA Credit Transfer (EPC)</string>
+    <string name="payment_type_bank_url">SEPA Credit Transfer</string>
+    <string name="payment_type_pix">Pix payment</string>
+    <string name="payment_type_emv">Payment code (EMV)</string>
+    <string name="payment_explanation_epc">Scanned SEPA payment data (EPC / GiroCode):</string>
+    <string name="payment_explanation_bank_url">Scanned SEPA payment data:</string>
+    <string name="payment_explanation_pix">Scanned payment data:</string>
+    <string name="payment_recipient_value">Recipient: %1$s</string>
+    <string name="payment_iban_value">IBAN: %1$s</string>
+    <string name="payment_bic_value">BIC: %1$s</string>
+    <string name="payment_amount_value">Amount: %1$s</string>
+    <string name="payment_purpose_value">Purpose: %1$s</string>
+    <string name="payment_purpose_code_value">Purpose code: %1$s</string>
+    <string name="payment_version_value">Version: %1$s</string>
+    <string name="payment_city_value">City: %1$s</string>
+    <string name="payment_country_value">Country: %1$s</string>
+    <string name="payment_pix_key_value">Pix key: %1$s</string>
+    <string name="payment_pix_info_value">Info: %1$s</string>
+    <string name="payment_reference_value">Reference: %1$s</string>
+    <string name="payment_copy_field">Copy field</string>
+    <string name="payment_copy_iban">Copy IBAN</string>
+    <string name="payment_copy_amount">Copy amount</string>
+    <string name="payment_copy_purpose">Copy purpose</string>
+    <string name="payment_copy_recipient">Copy recipient</string>
+    <string name="payment_copy_pix_key">Copy Pix key</string>
+    <string name="payment_copy_all">Copy everything</string>
 </resources>

--- a/app/src/test/java/com/secuso/privacyfriendlycodescanner/qrscanner/payment/Crc16Test.java
+++ b/app/src/test/java/com/secuso/privacyfriendlycodescanner/qrscanner/payment/Crc16Test.java
@@ -1,0 +1,41 @@
+/*
+    Privacy Friendly QR Scanner
+    Copyright (C) 2025 Privacy Friendly QR Scanner authors and SECUSO
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package com.secuso.privacyfriendlycodescanner.qrscanner.payment;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class Crc16Test {
+
+    @Test
+    public void matchesKnownCcittFalseVector() {
+        // Standard CRC-16/CCITT-FALSE check value for the ASCII string "123456789".
+        assertEquals(0x29B1, Crc16.compute("123456789"));
+        assertEquals("29B1", Crc16.computeHex("123456789"));
+    }
+
+    @Test
+    public void hexIsZeroPaddedAndUppercase() {
+        // Result must always be exactly four upper-case hex characters.
+        String hex = Crc16.computeHex("A");
+        assertEquals(4, hex.length());
+        assertEquals(hex.toUpperCase(), hex);
+    }
+}

--- a/app/src/test/java/com/secuso/privacyfriendlycodescanner/qrscanner/payment/IbanTest.java
+++ b/app/src/test/java/com/secuso/privacyfriendlycodescanner/qrscanner/payment/IbanTest.java
@@ -1,0 +1,53 @@
+/*
+    Privacy Friendly QR Scanner
+    Copyright (C) 2025 Privacy Friendly QR Scanner authors and SECUSO
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package com.secuso.privacyfriendlycodescanner.qrscanner.payment;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class IbanTest {
+
+    @Test
+    public void acceptsValidIbans() {
+        assertTrue(Iban.isValid("DE89370400440532013000"));
+        assertTrue(Iban.isValid("GB82WEST12345698765432"));
+        // Spaces are tolerated.
+        assertTrue(Iban.isValid("DE89 3704 0044 0532 0130 00"));
+        // Lower case is tolerated.
+        assertTrue(Iban.isValid("de89370400440532013000"));
+    }
+
+    @Test
+    public void rejectsInvalidIbans() {
+        assertFalse(Iban.isValid(null));
+        assertFalse(Iban.isValid(""));
+        assertFalse(Iban.isValid("DE89370400440532013001")); // wrong check digits
+        assertFalse(Iban.isValid("DE0037040044053201")); // too short
+        assertFalse(Iban.isValid("12345678901234567890")); // no country letters
+        assertFalse(Iban.isValid("DE89-3704-0044")); // illegal characters
+    }
+
+    @Test
+    public void normalizeStripsSpacesAndUppercases() {
+        assertEquals("DE89370400440532013000", Iban.normalize("de89 3704 0044 0532 0130 00"));
+    }
+}

--- a/app/src/test/java/com/secuso/privacyfriendlycodescanner/qrscanner/payment/PaymentCodeParserTest.java
+++ b/app/src/test/java/com/secuso/privacyfriendlycodescanner/qrscanner/payment/PaymentCodeParserTest.java
@@ -1,0 +1,180 @@
+/*
+    Privacy Friendly QR Scanner
+    Copyright (C) 2025 Privacy Friendly QR Scanner authors and SECUSO
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package com.secuso.privacyfriendlycodescanner.qrscanner.payment;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class PaymentCodeParserTest {
+
+    private static final String VALID_IBAN = "DE89370400440532013000";
+
+    // ------------------------------------------------------------------
+    // EPC / GiroCode
+    // ------------------------------------------------------------------
+
+    @Test
+    public void parsesValidEpcVersion002() {
+        String raw = "BCD\n002\n1\nSCT\nBFSWDE33MUE\nMax Mustermann\n" + VALID_IBAN
+                + "\nEUR123.45\nGDDS\n\nThank you for your donation\n";
+        PaymentCode code = PaymentCodeParser.parse(raw);
+        assertNotNull(code);
+        assertEquals(PaymentCode.Type.EPC, code.getType());
+        assertEquals("Max Mustermann", code.getRecipientName());
+        assertEquals(VALID_IBAN, code.getIban());
+        assertEquals("BFSWDE33MUE", code.getBic());
+        assertEquals("EUR", code.getCurrency());
+        assertEquals("123.45", code.getAmount());
+        assertEquals("123.45 EUR", code.getFormattedAmount());
+        assertEquals("Thank you for your donation", code.getRemittance());
+        assertEquals("002", code.getVersion());
+    }
+
+    @Test
+    public void parsesValidEpcVersion001WithBic() {
+        String raw = "BCD\n001\n1\nSCT\nCOBADEFFXXX\nAcme Inc\n" + VALID_IBAN + "\nEUR10\n";
+        PaymentCode code = PaymentCodeParser.parse(raw);
+        assertNotNull(code);
+        assertEquals("10", code.getAmount());
+    }
+
+    @Test
+    public void rejectsEpcVersion001WithoutBic() {
+        // BIC is mandatory in EPC version 001.
+        String raw = "BCD\n001\n1\nSCT\n\nAcme Inc\n" + VALID_IBAN + "\n";
+        assertNull(PaymentCodeParser.parse(raw));
+    }
+
+    @Test
+    public void rejectsEpcWithInvalidIban() {
+        String raw = "BCD\n002\n1\nSCT\nBFSWDE33MUE\nMax Mustermann\nDE89370400440532013001\n";
+        assertNull(PaymentCodeParser.parse(raw));
+    }
+
+    @Test
+    public void rejectsEpcWithMalformedAmount() {
+        String raw = "BCD\n002\n1\nSCT\nBFSWDE33MUE\nMax Mustermann\n" + VALID_IBAN + "\n12.50\n";
+        assertNull(PaymentCodeParser.parse(raw));
+    }
+
+    @Test
+    public void rejectsEpcWithWrongServiceTag() {
+        String raw = "ABC\n002\n1\nSCT\nBFSWDE33MUE\nMax Mustermann\n" + VALID_IBAN + "\n";
+        assertNull(PaymentCodeParser.parse(raw));
+    }
+
+    // ------------------------------------------------------------------
+    // bank://singlepaymentsepa
+    // ------------------------------------------------------------------
+
+    @Test
+    public void parsesValidBankUrl() {
+        String raw = "bank://singlepaymentsepa?name=DER%20EMPFAENGER&iban=" + VALID_IBAN
+                + "&amount=3.49&reason=EINKAUF%20BEI%20ALDI&currency=EUR";
+        PaymentCode code = PaymentCodeParser.parse(raw);
+        assertNotNull(code);
+        assertEquals(PaymentCode.Type.BANK_URL, code.getType());
+        assertEquals("DER EMPFAENGER", code.getRecipientName());
+        assertEquals(VALID_IBAN, code.getIban());
+        assertEquals("3.49", code.getAmount());
+        assertEquals("EUR", code.getCurrency());
+        assertEquals("EINKAUF BEI ALDI", code.getRemittance());
+    }
+
+    @Test
+    public void bankUrlIsCurrencyAgnostic() {
+        String raw = "bank://singlepaymentsepa?name=Shop&iban=" + VALID_IBAN + "&amount=5&currency=USD";
+        PaymentCode code = PaymentCodeParser.parse(raw);
+        assertNotNull(code);
+        assertEquals("USD", code.getCurrency());
+    }
+
+    @Test
+    public void rejectsBankUrlWithInvalidIban() {
+        String raw = "bank://singlepaymentsepa?name=Shop&iban=DE00370400440532013000&amount=5";
+        assertNull(PaymentCodeParser.parse(raw));
+    }
+
+    // ------------------------------------------------------------------
+    // EMV / Pix
+    // ------------------------------------------------------------------
+
+    @Test
+    public void parsesValidPix() {
+        PaymentCode code = PaymentCodeParser.parse(buildPix());
+        assertNotNull(code);
+        assertEquals(PaymentCode.Type.EMV, code.getType());
+        assertTrue(code.isPixScheme());
+        assertEquals("Fulano de Tal", code.getRecipientName());
+        assertEquals("BRASILIA", code.getCity());
+        assertEquals("BRL", code.getCurrency());
+        assertEquals("BR", code.getCountryCode());
+        assertEquals("test@example.com", code.getPixKey());
+    }
+
+    @Test
+    public void rejectsPixWithBrokenCrc() {
+        String pix = buildPix();
+        // Flip the last CRC character.
+        char last = pix.charAt(pix.length() - 1);
+        String broken = pix.substring(0, pix.length() - 1) + (last == '0' ? '1' : '0');
+        assertNull(PaymentCodeParser.parse(broken));
+    }
+
+    /** Builds a valid static Pix payload, computing a correct CRC over the body. */
+    private static String buildPix() {
+        String body = "000201"
+                + "2638" + "0014br.gov.bcb.pix" + "0116test@example.com"
+                + "52040000"
+                + "5303986"
+                + "5802BR"
+                + "5913Fulano de Tal"
+                + "6008BRASILIA"
+                + "6207" + "0503***"
+                + "6304";
+        return body + Crc16.computeHex(body);
+    }
+
+    // ------------------------------------------------------------------
+    // Negative cases: ordinary content must NOT be detected as a payment code
+    // ------------------------------------------------------------------
+
+    @Test
+    public void doesNotDetectPlainText() {
+        assertNull(PaymentCodeParser.parse("Hello world"));
+        assertNull(PaymentCodeParser.parse("BCD is a nice band"));
+    }
+
+    @Test
+    public void doesNotDetectOrdinaryUrl() {
+        assertNull(PaymentCodeParser.parse("https://example.com/path?a=1"));
+        assertNull(PaymentCodeParser.parse("http://000201.example.com"));
+    }
+
+    @Test
+    public void handlesNullAndEmpty() {
+        assertNull(PaymentCodeParser.parse(null));
+        assertNull(PaymentCodeParser.parse(""));
+        assertNull(PaymentCodeParser.parse("   "));
+    }
+}


### PR DESCRIPTION
Closes #98

Until now, scanning a payment QR code just dumped the raw text on screen
a wall of `BCD`, line breaks and an IBAN you had to pick apart by hand. This
changes that: recognised payment codes are shown as proper fields (recipient,
IBAN, amount, purpose …), like the contact or Wi-Fi results already do.

Three formats are detected:

- **EPC / GiroCode** (the `BCD` codes from German invoices)
- **bank://singlepaymentsepa** URLs
- **EMVCo** codes, which also covers **Pix** from Brazil

ZXing doesn't know about any of these, so I didn't touch its result types.
Instead a small, dependency-free `PaymentCodeParser` runs before the normal
dispatch in `ResultActivity`. If it recognises a code, a dedicated fragment
takes over; if not, everything falls through to the existing handling exactly
as before, so no existing result type changes behaviour.

Detection is deliberately strict to avoid false positives: a code is only
treated as a payment when the signature matches *and* the mandatory fields are
valid, IBAN checked with MOD 97-10, EMV/Pix verified against its CRC-16. A
normal URL or piece of text that merely looks similar is left alone. Currency
is read and shown but never used to accept or reject a code, so non-euro Pix
codes work too. The raw content is still one tap away via the existing dialog.

Worth noting for a privacy-friendly app: this is all done locally, with no new
libraries, no network calls and no new permissions. It's also display only,
generating these codes would be a separate change.

**Tested**
- New JVM unit tests for the parser, the IBAN check and the CRC-16, including
  negative cases making sure plain text and ordinary URLs are *not* picked up
  as payments.
- Built the debug APK in CI and scanned real EPC, bank:// and Pix codes on a
  device; non-payment codes still behave as before.

I've read the contribution guidelines, including the unwanted-changes policy: Changes.